### PR TITLE
fix/unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Maroto [![GoDoc](https://godoc.org/github.com/johnfercher/maroto?status.svg)](https://godoc.org/github.com/johnfercher/maroto) [![Travis](https://travis-ci.com/johnfercher/maroto.svg?branch=master)][travis] [![Code Coverage](https://img.shields.io/badge/coverage-95.1%25-brightgreen.svg)][test] [![Go Report Card](https://goreportcard.com/badge/github.com/johnfercher/maroto)](https://goreportcard.com/report/github.com/johnfercher/maroto)
+# Maroto [![GoDoc](https://godoc.org/github.com/johnfercher/maroto?status.svg)](https://godoc.org/github.com/johnfercher/maroto) [![Travis](https://travis-ci.com/johnfercher/maroto.svg?branch=master)][travis] [![Code Coverage](https://img.shields.io/badge/coverage-95.5%25-brightgreen.svg)][test] [![Go Report Card](https://goreportcard.com/badge/github.com/johnfercher/maroto)](https://goreportcard.com/report/github.com/johnfercher/maroto)
 A Maroto way to create PDFs. Maroto is inspired in Bootstrap and uses [Gofpdf](https://github.com/jung-kurt/gofpdf). Fast and simple.
 
 > Maroto definition: Brazilian expression, means an astute/clever/intelligent person.

--- a/issue_template.md
+++ b/issue_template.md
@@ -1,0 +1,26 @@
+<!-- Before submitting an issue, please consult our docs (https://godoc.org/github.com/johnfercher/maroto) -->
+
+**Maroto version:**
+<!-- Please, inform your maroto version -->
+
+**I'm submitting a ...** 
+<!--  (check one with "x") -->
+- [ ] bug report
+- [ ] feature request
+
+**Current behavior:**
+<!-- Describe how the bug manifests. -->
+
+**Expected behavior:**
+<!-- Describe what the behavior would be without the bug. -->
+
+**Steps to reproduce:**
+<!--  Please explain the steps required to duplicate the issue, especially if you are able to provide a sample application. -->
+
+**Related code:**
+```
+insert short code snippets here
+```
+
+**Other information:**
+<!-- List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc. -->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,21 +1,21 @@
-### Disclaimer
-Please, do not create a Pull Request directly to master branch, create to dev always.
+<!-- Please, do not create a Pull Request directly to master branch, create to dev always. -->
 
-### Title
-Please follow the PR naming pattern.
-* For features: feature/name
-* For fixes: fix/name
-* For documentation: doc/name
-* For tests: tests/name
-* For config: config/name
+<!-- Please follow the PR naming pattern. -->
+<!-- For features: feature/name -->
+<!-- For fixes: fix/name -->
+<!-- For documentation: doc/name -->
+<!-- For tests: tests/name -->
+<!-- For config: config/name -->
 
-### Description
-Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too.
+**Description**
+<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->
 
-### Related Issue
-If it has any issue related to this PR, please add a reference here.
+**Related Issue**
+<!-- If it has any issue related to this PR, please add a reference here. -->
 
-### Checklist
+**Checklist**
+<!--  (check one with "x") -->
+
 - [ ] All methods associated with structs has ```func (self *struct) method() {}``` name style.
 - [ ] Executed ```test.sh``` and updated the [README.md](README.md) with new code coverage data.
 - [ ] Wrote unit tests for new/changed features.

--- a/text.go
+++ b/text.go
@@ -28,12 +28,13 @@ func NewText(pdf gofpdf.Pdf, math Math, font Font) Text {
 func (self *text) Add(text string, fontFamily Family, fontStyle Style, fontSize float64, marginTop float64, align Align, actualCol float64, qtdCols float64) {
 	actualWidthPerCol := self.math.GetWidthPerCol(qtdCols)
 
+	translator := self.pdf.UnicodeTranslatorFromDescriptor("")
 	self.font.SetFont(fontFamily, fontStyle, fontSize)
 
 	left, top, _, _ := self.pdf.GetMargins()
 
 	if align == Left {
-		self.pdf.Text(actualCol*actualWidthPerCol+left, marginTop+top, text)
+		self.pdf.Text(actualCol*actualWidthPerCol+left, marginTop+top, translator(text))
 		return
 	}
 
@@ -42,8 +43,6 @@ func (self *text) Add(text string, fontFamily Family, fontStyle Style, fontSize 
 	if align == Right {
 		modifier = 1
 	}
-
-	translator := self.pdf.UnicodeTranslatorFromDescriptor("")
 
 	stringWidth := self.pdf.GetStringWidth(translator(text))
 	dx := (actualWidthPerCol - stringWidth) / modifier

--- a/text_test.go
+++ b/text_test.go
@@ -104,6 +104,45 @@ func TestText_Add(t *testing.T) {
 				_font.AssertCalled(t, "SetFont", maroto.Arial, maroto.BoldItalic, 16.0)
 			},
 		},
+		{
+			"Right Align",
+			maroto.Right,
+			func() *mocks.Pdf {
+				_pdf := &mocks.Pdf{}
+				_pdf.On("GetStringWidth", mock.Anything).Return(12.0)
+				_pdf.On("GetMargins").Return(10.0, 10.0, 10.0, 10.0)
+				_pdf.On("Text", mock.Anything, mock.Anything, mock.Anything)
+				_pdf.On("UnicodeTranslatorFromDescriptor", mock.Anything).Return(func(value string) string { return value })
+				return _pdf
+			},
+			func() *mocks.Math {
+				_math := &mocks.Math{}
+				_math.On("GetWidthPerCol", mock.Anything).Return(123.0)
+				return _math
+			},
+			func() *mocks.Font {
+				_font := &mocks.Font{}
+				_font.On("SetFont", mock.Anything, mock.Anything, mock.Anything)
+				return _font
+			},
+			func(t *testing.T, _pdf *mocks.Pdf) {
+				_pdf.AssertNumberOfCalls(t, "GetStringWidth", 1)
+				_pdf.AssertCalled(t, "GetStringWidth", "TextHelper")
+
+				_pdf.AssertNumberOfCalls(t, "GetMargins", 1)
+
+				_pdf.AssertNumberOfCalls(t, "Text", 1)
+				_pdf.AssertCalled(t, "Text", 244.0, 15.0, "TextHelper")
+			},
+			func(t *testing.T, _math *mocks.Math) {
+				_math.AssertNumberOfCalls(t, "GetWidthPerCol", 1)
+				_math.AssertCalled(t, "GetWidthPerCol", 15.0)
+			},
+			func(t *testing.T, _font *mocks.Font) {
+				_font.AssertNumberOfCalls(t, "SetFont", 1)
+				_font.AssertCalled(t, "SetFont", maroto.Arial, maroto.BoldItalic, 16.0)
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
**Description**

Nowadays, maroto only apply unicode to centralized texts. We will apply the translator in every text.

**Checklist**

- [x] All methods associated with structs has ```func (self *struct) method() {}``` name style.
- [x] Executed ```test.sh``` and updated the [README.md](README.md) with new code coverage data.
- [x] Wrote unit tests for new/changed features.