### PR TITLE
fix/95-barcode-proportion

### DIFF
--- a/pkg/pdf/example_test.go
+++ b/pkg/pdf/example_test.go
@@ -173,7 +173,7 @@ func ExamplePdfMaroto_TableList() {
 
 // ExamplePdfMaroto_FileImage demonstrates how add an Image
 // reading from disk.
-// When barcodeProp is nil, method make Image fulfill the context
+// When props.Rect is nil, method make Image fulfill the context
 // cell, based on width and cell from Image and cell.
 // When center is true, left and top has no effect.
 // Percent represents the width/height of the Image inside the cell:
@@ -286,6 +286,8 @@ func ExamplePdfMaroto_QrCode() {
 // In brief, when center parameter equals true, left and top parameters has no effect.
 // Percent parameter represents the Barcode's width/height inside the cell.
 // i.e. Percent: 75 means that the Barcode will take up 75% of Col's width
+// There is a constraint in the proportion defined, height cannot be greater than 20% of
+// the width, and height cannot be smaller than 10% of the width.
 func ExamplePdfMaroto_Barcode() {
 	m := pdf.NewMaroto(consts.Portrait, consts.A4)
 

--- a/pkg/props/prop.go
+++ b/pkg/props/prop.go
@@ -135,8 +135,10 @@ func (r *Barcode) MakeValid() {
 		r.Proportion.Height = 1
 	}
 
-	if r.Proportion.Height > r.Proportion.Width*0.33 {
-		r.Proportion.Height = r.Proportion.Width * 0.33
+	if r.Proportion.Height > r.Proportion.Width*0.20 {
+		r.Proportion.Height = r.Proportion.Width * 0.20
+	} else if r.Proportion.Height < r.Proportion.Width*0.10 {
+		r.Proportion.Height = r.Proportion.Width * 0.10
 	}
 }
 

--- a/pkg/props/prop_test.go
+++ b/pkg/props/prop_test.go
@@ -142,7 +142,31 @@ func TestBarcodeProp_MakeValid(t *testing.T) {
 				},
 			},
 			func(t *testing.T, prop props.Barcode) {
-				assert.Equal(t, prop.Proportion.Height, 0.33)
+				assert.Equal(t, prop.Proportion.Height, 0.20)
+			},
+		},
+		{
+			"When height is smaller than 10% of width",
+			props.Barcode{
+				Proportion: props.Proportion{
+					Width:  11,
+					Height: 1,
+				},
+			},
+			func(t *testing.T, prop props.Barcode) {
+				assert.Equal(t, prop.Proportion.Height, prop.Proportion.Width*0.10)
+			},
+		},
+		{
+			"When height is grather than 20% of width",
+			props.Barcode{
+				Proportion: props.Proportion{
+					Width:  5,
+					Height: 5,
+				},
+			},
+			func(t *testing.T, prop props.Barcode) {
+				assert.Equal(t, prop.Proportion.Height, prop.Proportion.Width*0.20)
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Please, do not create a Pull Request directly to master branch, create to dev always. -->

<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->
<!-- For documentation: doc/name -->
<!-- For tests: tests/name -->
<!-- For config: config/name -->

**Description**
Improve barcode proportions, by changing the proportion constrains. Height must be greater than 10% of the size of width and smaller than 20%.

The barcode should be something between the two images below.

<img width="969" alt="Captura de Tela 2019-10-17 às 22 33 36" src="https://user-images.githubusercontent.com/49728831/67059719-8e526700-f130-11e9-8858-024ffd510f45.png">

<img width="995" alt="Captura de Tela 2019-10-17 às 22 33 53" src="https://user-images.githubusercontent.com/49728831/67059734-94e0de80-f130-11e9-984d-5355ca4853c8.png">


**Related Issue**
resolve #95 

**Checklist**
> check with "x", if applied to your change

- [x] All methods associated with structs has ```func (s *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [x] Updated docs/doc.go <!-- If applied -->
- [x] Updated pkg/pdf/example_test.go <!-- If applied -->
- [x] Updated README.md <!-- If applied -->
- [x] New public methods has comments upside them explaining what it does <!-- If applied -->
- [x] Executed `go fmt github.com/johnfercher/maroto/...` to format all files