### PR TITLE
ISSUE-168, add method to set/unset compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ go get -u github.com/johnfercher/maroto
 * [SetFirstPageNb](https://pkg.go.dev/github.com/johnfercher/maroto/pkg/pdf#PdfMaroto.SetFirstPageNb): Set first number for page numbering
 * [AddUTF8Font](https://pkg.go.dev/github.com/johnfercher/maroto/pkg/pdf#PdfMaroto.AddUTF8Font): Add a custom utf8 font
 * [SetProtection](https://pkg.go.dev/github.com/johnfercher/maroto/pkg/pdf#PdfMaroto.SetProtection)
+* [SetCompression](https://pkg.go.dev/github.com/johnfercher/maroto/pkg/pdf#PdfMaroto.SetCompression) Set/ unset compression for a page. Default value is on 
 * [SetDefaultFontFamily](https://pkg.go.dev/github.com/johnfercher/maroto/pkg/pdf#PdfMaroto.SetProtection): Define a default font family, useful to use with a custom font.
 * Automatic New Page: New pages are generated automatically when needed.
 * 100% Unicode

--- a/pkg/pdf/example_test.go
+++ b/pkg/pdf/example_test.go
@@ -648,3 +648,12 @@ func ExamplePdfMaroto_SetProtection() {
 
 	// Do more things and save...
 }
+
+// ExamplePdfMaroto_SetCompression demonstrates how to disable compression
+func ExamplePdfMaroto_SetCompression() {
+	m := pdf.NewMaroto(consts.Portrait, consts.A4)
+
+	m.SetCompression(false)
+
+	// Do more things and save...
+}

--- a/pkg/pdf/example_test.go
+++ b/pkg/pdf/example_test.go
@@ -650,6 +650,7 @@ func ExamplePdfMaroto_SetProtection() {
 }
 
 // ExamplePdfMaroto_SetCompression demonstrates how to disable compression
+// By default compression is enabled
 func ExamplePdfMaroto_SetCompression() {
 	m := pdf.NewMaroto(consts.Portrait, consts.A4)
 

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -284,7 +284,8 @@ func (s *PdfMaroto) SetAliasNbPages(alias string) {
 	s.Pdf.AliasNbPages(alias)
 }
 
-// SetCompression allows to set/unset compression for a pdf
+// SetCompression allows to set/unset compression for a page
+// Compression is on by default.
 func (s *PdfMaroto) SetCompression(compress bool) {
 	s.Pdf.SetCompression(compress)
 }

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -2,6 +2,7 @@ package pdf
 
 import (
 	"bytes"
+
 	"github.com/johnfercher/maroto/internal/fpdf"
 	"github.com/johnfercher/maroto/pkg/color"
 
@@ -50,6 +51,7 @@ type Maroto interface {
 	GetCurrentOffset() float64
 	SetPageMargins(left, top, right float64)
 	GetPageMargins() (left float64, top float64, right float64, bottom float64)
+	SetCompression(compress bool)
 
 	// Fonts
 	AddUTF8Font(familyStr string, styleStr consts.Style, fileStr string)
@@ -280,6 +282,11 @@ func (s *PdfMaroto) SetFirstPageNb(number int) {
 // It will be substituted as the document is closed.
 func (s *PdfMaroto) SetAliasNbPages(alias string) {
 	s.Pdf.AliasNbPages(alias)
+}
+
+// SetCompression allows to set/unset compression for a pdf
+func (s *PdfMaroto) SetCompression(compress bool) {
+	s.Pdf.SetCompression(compress)
 }
 
 // GetBorder return the actual border value.

--- a/pkg/pdf/pdf_test.go
+++ b/pkg/pdf/pdf_test.go
@@ -1618,6 +1618,7 @@ func baseFpdfTest(left, top, right float64) *mocks.Fpdf {
 	Fpdf.On("SetFillColor", mock.Anything, mock.Anything, mock.Anything)
 	Fpdf.On("AddUTF8Font", mock.Anything, mock.Anything, mock.Anything)
 	Fpdf.On("SetProtection", mock.Anything, mock.Anything, mock.Anything)
+	Fpdf.On("SetCompression", mock.Anything)
 	return Fpdf
 }
 
@@ -2046,4 +2047,16 @@ func TestPdfMaroto_SetGetDefaultFontFamily(t *testing.T) {
 
 	// Assert
 	assert.Equal(t, family, "family")
+}
+
+func TestPdfMaroto_SetCompression(t *testing.T) {
+	// Arrange
+	Fpdf := baseFpdfTest(10.0, 10.0, 10.0)
+	m := newMarotoTest(Fpdf, nil, nil, nil, nil, nil, nil, nil)
+
+	// Act
+	m.SetCompression(false)
+
+	// Assert
+	Fpdf.AssertCalled(t, "SetCompression", false)
 }


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->
<!-- For documentation: doc/name -->
<!-- For tests: tests/name -->
<!-- For config: config/name -->

**Description**
Added setCompression method which will allow to turn off compression for pdf

**Related Issue**
Resolves https://github.com/johnfercher/maroto/issues/168
**Checklist**
> check with "x", if applied to your change

- [x] All methods associated with structs has ```func (s *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [x] Updated docs/doc.go <!-- If applied -->
- [x] Updated pkg/pdf/example_test.go <!-- If applied -->
- [x] Updated README.md <!-- If applied -->
- [ ] Updated all examples inside internal/examples <!-- If applied -->
- [x] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [x] Executed `go fmt github.com/johnfercher/maroto/...` to format all files