### PR TITLE
feature/set-font-location

### DIFF
--- a/pkg/pdf/example_test.go
+++ b/pkg/pdf/example_test.go
@@ -3,12 +3,13 @@ package pdf_test
 import (
 	"encoding/base64"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/johnfercher/maroto/pkg/color"
 	"github.com/johnfercher/maroto/pkg/consts"
 	"github.com/johnfercher/maroto/pkg/pdf"
 	"github.com/johnfercher/maroto/pkg/props"
-	"testing"
-	"time"
 )
 
 // ExampleNewMaroto demonstrates how to create maroto
@@ -592,6 +593,31 @@ func ExamplePdfMaroto_AddUTF8Font() {
 	m.AddUTF8Font("CustomArial", consts.Italic, "internal/assets/fonts/arial-unicode-ms.ttf")
 	m.AddUTF8Font("CustomArial", consts.Bold, "internal/assets/fonts/arial-unicode-ms.ttf")
 	m.AddUTF8Font("CustomArial", consts.BoldItalic, "internal/assets/fonts/arial-unicode-ms.ttf")
+
+	m.Row(10, func() {
+		m.Col(12, func() {
+			// Use style
+			m.Text("CustomUtf8Font", props.Text{
+				Family: "CustomArial",
+			})
+		})
+	})
+
+	// Do more things and save...
+}
+
+// ExamplePdfMaroto_SetFontLocation demonstrates how to add a custom utf8 font from custom location
+func ExamplePdfMaroto_SetFontLocation() {
+	m := pdf.NewMaroto(consts.Portrait, consts.A4)
+
+	// Define custom location. It might be an absolute path as well as a relative path
+	m.SetFontLocation("internal/assets/fonts/")
+
+	// Define font to all styles
+	m.AddUTF8Font("CustomArial", consts.Normal, "arial-unicode-ms.ttf")
+	m.AddUTF8Font("CustomArial", consts.Italic, "arial-unicode-ms.ttf")
+	m.AddUTF8Font("CustomArial", consts.Bold, "arial-unicode-ms.ttf")
+	m.AddUTF8Font("CustomArial", consts.BoldItalic, "arial-unicode-ms.ttf")
 
 	m.Row(10, func() {
 		m.Col(12, func() {

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -55,6 +55,7 @@ type Maroto interface {
 
 	// Fonts
 	AddUTF8Font(familyStr string, styleStr consts.Style, fileStr string)
+	SetFontLocation(fontDirStr string)
 	SetProtection(actionFlag byte, userPassStr, ownerPassStr string)
 	SetDefaultFontFamily(fontFamily string)
 	GetDefaultFontFamily() string
@@ -519,6 +520,11 @@ func (s *PdfMaroto) Output() (bytes.Buffer, error) {
 // styleStr is the style of the font and fileStr is the path to the .ttf file.
 func (s *PdfMaroto) AddUTF8Font(familyStr string, styleStr consts.Style, fileStr string) {
 	s.Pdf.AddUTF8Font(familyStr, string(styleStr), fileStr)
+}
+
+// SetFontLocation allows you to change the fonts lookup location.  fontDirStr is an absolute path where the fonts should be located
+func (s *PdfMaroto) SetFontLocation(fontDirStr string) {
+	s.Pdf.SetFontLocation(fontDirStr)
 }
 
 // SetProtection define a password to open the pdf

--- a/pkg/pdf/pdf_test.go
+++ b/pkg/pdf/pdf_test.go
@@ -3,9 +3,10 @@ package pdf_test
 import (
 	"bytes"
 	"fmt"
+	"testing"
+
 	"github.com/johnfercher/maroto/internal"
 	"github.com/johnfercher/maroto/pkg/color"
-	"testing"
 
 	"github.com/johnfercher/maroto/internal/mocks"
 	"github.com/johnfercher/maroto/pkg/consts"
@@ -1617,6 +1618,7 @@ func baseFpdfTest(left, top, right float64) *mocks.Fpdf {
 	Fpdf.On("SetMargins", mock.AnythingOfType("float64"), mock.AnythingOfType("float64"), mock.AnythingOfType("float64"))
 	Fpdf.On("SetFillColor", mock.Anything, mock.Anything, mock.Anything)
 	Fpdf.On("AddUTF8Font", mock.Anything, mock.Anything, mock.Anything)
+	Fpdf.On("SetFontLocation", mock.Anything)
 	Fpdf.On("SetProtection", mock.Anything, mock.Anything, mock.Anything)
 	Fpdf.On("SetCompression", mock.Anything)
 	return Fpdf
@@ -2022,6 +2024,18 @@ func TestPdfMaroto_AddUTF8Font(t *testing.T) {
 
 	// Assert
 	Fpdf.AssertCalled(t, "AddUTF8Font", "family", "style", "file")
+}
+
+func TestPdfMaroto_SetFontLocation(t *testing.T) {
+	// Arrange
+	Fpdf := baseFpdfTest(10.0, 10.0, 10.0)
+	m := newMarotoTest(Fpdf, nil, nil, nil, nil, nil, nil, nil)
+
+	// Act
+	m.SetFontLocation("/opt/fonts")
+
+	// Assert
+	Fpdf.AssertCalled(t, "SetFontLocation", "/opt/fonts")
 }
 
 func TestPdfMaroto_SetProtection(t *testing.T) {


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->
<!-- For documentation: doc/name -->
<!-- For tests: tests/name -->
<!-- For config: config/name -->

**Description**
<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->
It seems that you can't add custom font by the absolute path using `AddUTF8Font()`. In order to resolve the problem, I suppose to add the `func (s *PdfMaroto) SetFontLocation(fontDirStr string)` method which changes the fonts look-up folder. It might be useful when you want to add a custom font by the absolute path.

**Related Issue**
<!-- If it has any issue related to this PR, please add a reference here. -->
https://github.com/johnfercher/maroto/issues/172

**Checklist**
> check with "x", if applied to your change

- [x] All methods associated with structs has ```func (s *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [ ] Updated docs/doc.go <!-- If applied -->
- [x] Updated pkg/pdf/example_test.go <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] Updated all examples inside internal/examples <!-- If applied -->
- [x] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [x] Executed `go fmt github.com/johnfercher/maroto/...` to format all files