### PR TITLE
Feature/231: Use provided top value when setting page margin

### DIFF
--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -226,7 +226,7 @@ func (s *PdfMaroto) SetPageMargins(left, top, right float64) {
 		s.marginTop = top - defaultTopMargin
 	}
 
-	s.Pdf.SetMargins(left, defaultTopMargin, right)
+	s.Pdf.SetMargins(left, top, right)
 }
 
 // GetPageMargins returns the set page margins. Comes in order of Left, Top, Right, Bottom

--- a/pkg/pdf/pdf_test.go
+++ b/pkg/pdf/pdf_test.go
@@ -2611,7 +2611,7 @@ func TestFpdfMaroto_SetPageMargins(t *testing.T) {
 				m.SetPageMargins(12.3, 19.3, 0.0)
 			},
 			func(t *testing.T, m *mocks.Fpdf) {
-				m.AssertCalled(t, "SetMargins", 12.3, 10.0, 0.0)
+				m.AssertCalled(t, "SetMargins", 12.3, 19.3, 0.0)
 			},
 		},
 		{
@@ -2620,7 +2620,7 @@ func TestFpdfMaroto_SetPageMargins(t *testing.T) {
 				m.SetPageMargins(12.3, 9.0, 0.0)
 			},
 			func(t *testing.T, m *mocks.Fpdf) {
-				m.AssertCalled(t, "SetMargins", 12.3, 10.0, 0.0)
+				m.AssertCalled(t, "SetMargins", 12.3, 9.0, 0.0)
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->
This PR make SetPageMargins use the provided top value and don't force the use of `defaultTopMargin`

**Related Issue**
<!-- If it has any issue related to this PR, please add a reference here. -->
#231 

**Checklist**
> check with "x", if applied to your change

- [ ] All methods associated with structs has ```func (s *struct) method() {}``` name style. <!-- If applied -->
- [ ] Wrote unit tests for new/changed features. <!-- If applied -->
- [ ] Updated docs/doc.go <!-- If applied -->
- [ ] Updated pkg/pdf/example_test.go <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] Updated all examples inside internal/examples <!-- If applied -->
- [ ] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [ ] Executed `make dod` with none issues pointed out by `golangci-lint` and `goreportcard-cli`