### PR TITLE
Fix orientation when page size is set up

### DIFF
--- a/pkg/config/builder.go
+++ b/pkg/config/builder.go
@@ -53,6 +53,7 @@ type builder struct {
 	pageNumberPlace   props.Place
 	protection        *entity.Protection
 	compression       bool
+	pageSize          *pagesize.Type
 	orientation       orientation.Type
 	metadata          *entity.Metadata
 	backgroundImage   *entity.Image
@@ -83,12 +84,7 @@ func (b *builder) WithPageSize(size pagesize.Type) Builder {
 		return b
 	}
 
-	width, height := pagesize.GetDimensions(size)
-	b.dimensions = &entity.Dimensions{
-		Width:  width,
-		Height: height,
-	}
-
+	b.pageSize = &size
 	return b
 }
 
@@ -311,7 +307,12 @@ func (b *builder) getDimensions() *entity.Dimensions {
 		return b.dimensions
 	}
 
-	width, height := pagesize.GetDimensions(pagesize.A4)
+	pageSize := pagesize.A4
+	if b.pageSize != nil {
+		pageSize = *b.pageSize
+	}
+
+	width, height := pagesize.GetDimensions(pageSize)
 	dimensions := &entity.Dimensions{
 		Width:  width,
 		Height: height,


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->

After calling the `WithPageSize` function, the `Dimensions` field is set in the `builder` struct, causing the `WithOrientation` function to have no effect.

**Related Issue**
<!-- If it has any issue related to this PR, please add a reference here. -->

**Checklist**
> check with "x", if applied to your change

- [x] Executed `make dod` with none issues pointed out by `golangci-lint`