### PR TITLE
Fix getting false extension of file if path contains a dot when loading images

### DIFF
--- a/internal/providers/gofpdf/provider.go
+++ b/internal/providers/gofpdf/provider.go
@@ -2,6 +2,7 @@ package gofpdf
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 
 	"github.com/johnfercher/maroto/v2/internal/providers/gofpdf/gofpdfwrapper"
@@ -111,7 +112,7 @@ func (g *provider) AddBarCode(code string, cell *entity.Cell, prop *props.Barcod
 }
 
 func (g *provider) AddImageFromFile(file string, cell *entity.Cell, prop *props.Rect) {
-	extensionStr := strings.Split(file, ".")[1]
+	extensionStr := strings.ToLower(strings.TrimPrefix(filepath.Ext(file), "."))
 	image, err := g.cache.GetImage(file, extension.Type(extensionStr))
 	if err != nil {
 		err = g.cache.LoadImage(file, extension.Type(extensionStr))


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->
Previously if the file path of an image had more than one dot, the extension of the file would not have been retrieved. Also this PR fixes a crash that would occur if the file path did not contain any dots.

**Related Issue**
<!-- If it has any issue related to this PR, please add a reference here. -->
Fixes #377

**Checklist**
> check with "x", if applied to your change

- [x] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [x] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [x] Updated docs/doc.go and docs/* <!-- If applied -->
- [x] Updated pkg/pdf/example_test.go <!-- If applied -->
- [x] Updated README.md <!-- If applied -->
- [x] Executed `make examples` to update all examples inside docs/examples. <!-- If applied -->
- [x] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [x] Executed `make dod` with none issues pointed out by `golangci-lint`