### PR TITLE
feature/load fonts as byte streams

### DIFF
--- a/mocks/Repository.go
+++ b/mocks/Repository.go
@@ -44,6 +44,11 @@ func (_m *Repository) AddUTF8Font(family string, style fontstyle.Type, file stri
 	return r0
 }
 
+func (_m *Repository) AddUTF8FontFromBytes(family string, style fontstyle.Type, bytes []byte) repository.Repository {
+	var r0 repository.Repository
+	return r0
+}
+
 // Repository_AddUTF8Font_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddUTF8Font'
 type Repository_AddUTF8Font_Call struct {
 	*mock.Call

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -11,6 +11,7 @@ import (
 // Repository is the abstraction to load custom fonts.
 type Repository interface {
 	AddUTF8Font(family string, style fontstyle.Type, file string) Repository
+	AddUTF8FontFromBytes(family string, style fontstyle.Type, bytes []byte) Repository
 	Load() ([]*entity.CustomFont, error)
 }
 
@@ -46,9 +47,35 @@ func (r *FontRepository) AddUTF8Font(family string, style fontstyle.Type, file s
 	return r
 }
 
+// AddUTF8FontFromBytes adds a custom font to the repository from a byte slice.
+func (r *FontRepository) AddUTF8FontFromBytes(family string, style fontstyle.Type, bytes []byte) Repository {
+	if family == "" {
+		return r
+	}
+
+	if !style.IsValid() {
+		return r
+	}
+
+	if bytes == nil {
+		return r
+	}
+
+	r.customFonts = append(r.customFonts, &entity.CustomFont{
+		Family: family,
+		Style:  style,
+		Bytes:  bytes,
+	})
+
+	return r
+}
+
 // Load loads all custom fonts.
 func (r *FontRepository) Load() ([]*entity.CustomFont, error) {
 	for _, customFont := range r.customFonts {
+		if customFont.File == "" {
+			continue
+		}
 		bytes, err := os.ReadFile(customFont.File)
 		if err != nil {
 			return nil, err

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -23,7 +23,7 @@ func TestRepository_AddUTF8Font(t *testing.T) {
 
 		// Assert
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(customFonts))
+		assert.Len(t, customFonts, 0)
 	})
 
 	t.Run("when fontstyle style is invalid, should not add value", func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestRepository_AddUTF8Font(t *testing.T) {
 
 		// Assert
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(customFonts))
+		assert.Len(t, customFonts, 0)
 	})
 
 	t.Run("when fontstyle file is empty, should not add value", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestRepository_AddUTF8Font(t *testing.T) {
 
 		// Assert
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(customFonts))
+		assert.Len(t, customFonts, 0)
 	})
 
 	t.Run("when fontstyle is valid, should not value", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestRepository_AddUTF8Font(t *testing.T) {
 
 		// Assert
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(customFonts))
+		assert.Len(t, customFonts, 1)
 		assert.Equal(t, "family", customFonts[0].Family)
 		assert.Equal(t, fontstyle.Bold, customFonts[0].Style)
 		assert.NotEmpty(t, customFonts[0].File)
@@ -77,7 +77,7 @@ func TestRepository_AddUTF8FontFromBytes(t *testing.T) {
 
 		// Assert
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(customFonts))
+		assert.Len(t, customFonts, 0)
 	})
 
 	t.Run("when fontstyle style is invalid, should not add value", func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestRepository_AddUTF8FontFromBytes(t *testing.T) {
 
 		// Assert
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(customFonts))
+		assert.Len(t, customFonts, 0)
 	})
 
 	t.Run("when fontstyle bytes is nil, should not add value", func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestRepository_AddUTF8FontFromBytes(t *testing.T) {
 
 		// Assert
 		assert.Nil(t, err)
-		assert.Equal(t, 0, len(customFonts))
+		assert.Len(t, customFonts, 0)
 	})
 
 	t.Run("when fontstyle is valid, should not value", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestRepository_AddUTF8FontFromBytes(t *testing.T) {
 
 		// Assert
 		assert.Nil(t, err)
-		assert.Equal(t, 1, len(customFonts))
+		assert.Len(t, customFonts, 1)
 		assert.Equal(t, "family", customFonts[0].Family)
 		assert.Equal(t, fontstyle.Bold, customFonts[0].Style)
 		assert.Empty(t, customFonts[0].File)

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/johnfercher/maroto/v2/pkg/consts/fontstyle"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRepository_AddUTF8Font(t *testing.T) {
@@ -62,6 +63,62 @@ func TestRepository_AddUTF8Font(t *testing.T) {
 		assert.Equal(t, "family", customFonts[0].Family)
 		assert.Equal(t, fontstyle.Bold, customFonts[0].Style)
 		assert.NotEmpty(t, customFonts[0].File)
+		assert.NotEmpty(t, customFonts[0].Bytes)
+	})
+}
+
+func TestRepository_AddUTF8FontFromBytes(t *testing.T) {
+	t.Run("when fontstyle family is empty, should not add value", func(t *testing.T) {
+		// Arrange
+		sut := repository.New()
+
+		// Act
+		customFonts, err := sut.AddUTF8FontFromBytes("", fontstyle.Bold, []byte(``)).Load()
+
+		// Assert
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(customFonts))
+	})
+
+	t.Run("when fontstyle style is invalid, should not add value", func(t *testing.T) {
+		// Arrange
+		sut := repository.New()
+
+		// Act
+		customFonts, err := sut.AddUTF8FontFromBytes("family", "invalid", []byte(``)).Load()
+
+		// Assert
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(customFonts))
+	})
+
+	t.Run("when fontstyle bytes is nil, should not add value", func(t *testing.T) {
+		// Arrange
+		sut := repository.New()
+
+		// Act
+		customFonts, err := sut.AddUTF8FontFromBytes("family", fontstyle.Bold, nil).Load()
+
+		// Assert
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(customFonts))
+	})
+
+	t.Run("when fontstyle is valid, should not value", func(t *testing.T) {
+		// Arrange
+		sut := repository.New()
+		ttf, err := os.ReadFile(buildPath("/docs/assets/fonts/arial-unicode-ms.ttf"))
+		require.NoError(t, err)
+
+		// Act
+		customFonts, err := sut.AddUTF8FontFromBytes("family", fontstyle.Bold, ttf).Load()
+
+		// Assert
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(customFonts))
+		assert.Equal(t, "family", customFonts[0].Family)
+		assert.Equal(t, fontstyle.Bold, customFonts[0].Style)
+		assert.Empty(t, customFonts[0].File)
 		assert.NotEmpty(t, customFonts[0].Bytes)
 	})
 }


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->

Allow Repository to accept font files as Byte streams directly instead of loading from files. This is specially useful when using `go:embed` to include the asset files in the binary generating the PDFs.

As we require to call `Load()` we have to circumvent the file parsing there for cases where the file path is empty.

**Checklist**
> check with "x", if applied to your change

- [x] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [ ] Wrote unit tests for new/changed features. <!-- If applied -->
- [ ] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] Updated docs/doc.go and docs/* <!-- If applied -->
- [ ] Updated example_test.go <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] Executed `make examples` to update all examples inside docs/examples. <!-- If applied -->
- [x] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [x] Executed `make dod` with none issues pointed out by `golangci-lint`