### PR TITLE
Define unit of row height

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ This is part of the [billing example](v2/examples/billing?id=billing).
 ### Rows
 
 - **Vertical Structuring**: Rows in Maroto are used to organize content vertically. Each row acts as a horizontal container for columns.
-- **Row Height**: The height of a row is defined when it is created (e.g., row.New(20)). This height determines the vertical space allocated for the row. Unlike columns, row height is not based on a grid system but is a relative unit of measurement.
+- **Row Height**: The height of a row is defined when it is created (e.g., row.New(20)). This height determines the vertical space allocated for the row. Unlike columns, row height is not based on a grid system but is a relative unit of `mm`.
 - **Sequential Layout**: Rows are added to the document in the order they are defined, creating a top-to-bottom flow of content. Each new row is placed immediately below the preceding row.
 - **Layout Flexibility**: Rows offer flexibility in the layout design, allowing for various configurations of columns within them. From single full-width columns to multiple columns of different widths, rows accommodate diverse layout patterns.
 

--- a/pkg/components/row/row.go
+++ b/pkg/components/row/row.go
@@ -18,6 +18,7 @@ type Row struct {
 }
 
 // New is responsible to create a core.Row.
+// height is defined in mm
 func New(height float64) core.Row {
 	return &Row{
 		height: height,


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->
* Define unit of row height in documentation.

**Related Issue**
<!-- If it has any issue related to this PR, please add a reference here. -->
#420 

**Checklist**
> check with "x", **ONLY IF APPLIED** to your change

- [ ] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [ ] Wrote unit tests for new/changed features. <!-- If applied -->
- [ ] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [ ] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/doc.go and docs/* <!-- If applied -->
- [ ] Updated example_test.go <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] Executed `make examples` to update all examples inside docs/examples. <!-- If applied -->
- [ ] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [ ] Executed `make dod` with none issues pointed out by `golangci-lint`