### PR TITLE
features/add method to return pdf settings

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -78,6 +78,15 @@ func ExampleMaroto_FitlnCurrentPage() {
 	// Do things and generate
 }
 
+// ExampleMaroto_FitlnCurrentPage demonstrate how to check if the new line fits on the current page
+func ExampleMaroto_GetCurrentConfig() {
+	m := maroto.New()
+
+	m.GetCurrentConfig()
+
+	// Do things and generate
+}
+
 // ExampleMaroto_RegisterHeader demonstrates how to register a header to me added in every new page.
 // An error is returned if the area occupied by the header is greater than the page area.
 func ExampleMaroto_RegisterHeader() {

--- a/maroto.go
+++ b/maroto.go
@@ -45,6 +45,11 @@ type Maroto struct {
 	pool async.Processor[[]core.Page, []byte]
 }
 
+// GetCurrentConfig is responsible for returning the current settings from the file
+func (m *Maroto) GetCurrentConfig() *entity.Config {
+	return m.config
+}
+
 // New is responsible for create a new instance of core.Maroto.
 // It's optional to provide an *entity.Config with customizations
 // those customization are created by using the config.Builder.

--- a/maroto_test.go
+++ b/maroto_test.go
@@ -371,6 +371,16 @@ func TestMaroto_FitlnCurrentPage(t *testing.T) {
 	})
 }
 
+func TestMaroto_GetCurrentConfig(t *testing.T) {
+	t.Run("When GetCurrentConfig is called then current settings are returned", func(t *testing.T) {
+		sut := maroto.New(config.NewBuilder().
+			WithMaxGridSize(20).
+			Build())
+
+		assert.Equal(t, sut.GetCurrentConfig().MaxGridSize, 20)
+	})
+}
+
 // nolint:dupl // dupl is good here
 func TestMaroto_RegisterHeader(t *testing.T) {
 	t.Run("when header size is greater than useful area, should return error", func(t *testing.T) {

--- a/metricsdecorator.go
+++ b/metricsdecorator.go
@@ -4,6 +4,7 @@ import (
 	"github.com/johnfercher/go-tree/node"
 	"github.com/johnfercher/maroto/v2/internal/time"
 	"github.com/johnfercher/maroto/v2/pkg/core"
+	"github.com/johnfercher/maroto/v2/pkg/core/entity"
 	"github.com/johnfercher/maroto/v2/pkg/metrics"
 )
 
@@ -28,6 +29,11 @@ func NewMetricsDecorator(inner core.Maroto) core.Maroto {
 
 func (m *MetricsDecorator) FitlnCurrentPage(heightNewLine float64) bool {
 	return m.inner.FitlnCurrentPage(heightNewLine)
+}
+
+// GetCurrentConfig decorates the GetCurrentConfig method of maroto instance.
+func (m *MetricsDecorator) GetCurrentConfig() *entity.Config {
+	return m.inner.GetCurrentConfig()
 }
 
 // Generate decorates the Generate method of maroto instance.

--- a/mocks/Builder.go
+++ b/mocks/Builder.go
@@ -78,8 +78,7 @@ func (_c *Builder_Build_Call) RunAndReturn(run func(*entity.Config, cache.Cache)
 func NewBuilder(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Builder {
+}) *Builder {
 	mock := &Builder{}
 	mock.Mock.Test(t)
 

--- a/mocks/Cache.go
+++ b/mocks/Cache.go
@@ -167,8 +167,7 @@ func (_c *Cache_LoadImage_Call) RunAndReturn(run func(string, extension.Type) er
 func NewCache(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Cache {
+}) *Cache {
 	mock := &Cache{}
 	mock.Mock.Test(t)
 

--- a/mocks/CellWriter.go
+++ b/mocks/CellWriter.go
@@ -190,8 +190,7 @@ func (_c *CellWriter_SetNext_Call) RunAndReturn(run func(cellwriter.CellWriter))
 func NewCellWriter(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *CellWriter {
+}) *CellWriter {
 	mock := &CellWriter{}
 	mock.Mock.Test(t)
 

--- a/mocks/Code.go
+++ b/mocks/Code.go
@@ -203,8 +203,7 @@ func (_c *Code_GenQr_Call) RunAndReturn(run func(string) (*entity.Image, error))
 func NewCode(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Code {
+}) *Code {
 	mock := &Code{}
 	mock.Mock.Test(t)
 

--- a/mocks/Col.go
+++ b/mocks/Col.go
@@ -300,8 +300,7 @@ func (_c *Col_WithStyle_Call) RunAndReturn(run func(*props.Cell) core.Col) *Col_
 func NewCol(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Col {
+}) *Col {
 	mock := &Col{}
 	mock.Mock.Test(t)
 

--- a/mocks/Component.go
+++ b/mocks/Component.go
@@ -143,8 +143,7 @@ func (_c *Component_SetConfig_Call) RunAndReturn(run func(*entity.Config)) *Comp
 func NewComponent(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Component {
+}) *Component {
 	mock := &Component{}
 	mock.Mock.Test(t)
 

--- a/mocks/Document.go
+++ b/mocks/Document.go
@@ -256,8 +256,7 @@ func (_c *Document_Save_Call) RunAndReturn(run func(string) error) *Document_Sav
 func NewDocument(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Document {
+}) *Document {
 	mock := &Document{}
 	mock.Mock.Test(t)
 

--- a/mocks/Font.go
+++ b/mocks/Font.go
@@ -486,8 +486,7 @@ func (_c *Font_SetStyle_Call) RunAndReturn(run func(fontstyle.Type)) *Font_SetSt
 func NewFont(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Font {
+}) *Font {
 	mock := &Font{}
 	mock.Mock.Test(t)
 

--- a/mocks/Fpdf.go
+++ b/mocks/Fpdf.go
@@ -6934,8 +6934,7 @@ func (_c *Fpdf_Writef_Call) RunAndReturn(run func(float64, string, ...interface{
 func NewFpdf(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Fpdf {
+}) *Fpdf {
 	mock := &Fpdf{}
 	mock.Mock.Test(t)
 

--- a/mocks/Image.go
+++ b/mocks/Image.go
@@ -80,8 +80,7 @@ func (_c *Image_Add_Call) RunAndReturn(run func(*entity.Image, *entity.Cell, *en
 func NewImage(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Image {
+}) *Image {
 	mock := &Image{}
 	mock.Mock.Test(t)
 

--- a/mocks/Line.go
+++ b/mocks/Line.go
@@ -61,8 +61,7 @@ func (_c *Line_Add_Call) RunAndReturn(run func(*entity.Cell, *props.Line)) *Line
 func NewLine(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Line {
+}) *Line {
 	mock := &Line{}
 	mock.Mock.Test(t)
 

--- a/mocks/Listable.go
+++ b/mocks/Listable.go
@@ -121,8 +121,7 @@ func (_c *Listable_GetHeader_Call) RunAndReturn(run func() core.Row) *Listable_G
 func NewListable(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Listable {
+}) *Listable {
 	mock := &Listable{}
 	mock.Mock.Test(t)
 

--- a/mocks/Maroto.go
+++ b/mocks/Maroto.go
@@ -4,6 +4,8 @@ package mocks
 
 import (
 	core "github.com/johnfercher/maroto/v2/pkg/core"
+	entity "github.com/johnfercher/maroto/v2/pkg/core/entity"
+
 	mock "github.com/stretchr/testify/mock"
 
 	node "github.com/johnfercher/go-tree/node"
@@ -280,6 +282,53 @@ func (_c *Maroto_Generate_Call) RunAndReturn(run func() (core.Document, error)) 
 	return _c
 }
 
+// GetCurrentConfig provides a mock function with given fields:
+func (_m *Maroto) GetCurrentConfig() *entity.Config {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCurrentConfig")
+	}
+
+	var r0 *entity.Config
+	if rf, ok := ret.Get(0).(func() *entity.Config); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*entity.Config)
+		}
+	}
+
+	return r0
+}
+
+// Maroto_GetCurrentConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCurrentConfig'
+type Maroto_GetCurrentConfig_Call struct {
+	*mock.Call
+}
+
+// GetCurrentConfig is a helper method to define mock.On call
+func (_e *Maroto_Expecter) GetCurrentConfig() *Maroto_GetCurrentConfig_Call {
+	return &Maroto_GetCurrentConfig_Call{Call: _e.mock.On("GetCurrentConfig")}
+}
+
+func (_c *Maroto_GetCurrentConfig_Call) Run(run func()) *Maroto_GetCurrentConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Maroto_GetCurrentConfig_Call) Return(_a0 *entity.Config) *Maroto_GetCurrentConfig_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Maroto_GetCurrentConfig_Call) RunAndReturn(run func() *entity.Config) *Maroto_GetCurrentConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetStructure provides a mock function with given fields:
 func (_m *Maroto) GetStructure() *node.Node[core.Structure] {
 	ret := _m.Called()
@@ -450,8 +499,7 @@ func (_c *Maroto_RegisterHeader_Call) RunAndReturn(run func(...core.Row) error) 
 func NewMaroto(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Maroto {
+}) *Maroto {
 	mock := &Maroto{}
 	mock.Mock.Test(t)
 

--- a/mocks/Math.go
+++ b/mocks/Math.go
@@ -127,8 +127,7 @@ func (_c *Math_GetInnerNonCenterCell_Call) RunAndReturn(run func(*entity.Dimensi
 func NewMath(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Math {
+}) *Math {
 	mock := &Math{}
 	mock.Mock.Test(t)
 

--- a/mocks/Node.go
+++ b/mocks/Node.go
@@ -109,8 +109,7 @@ func (_c *Node_SetConfig_Call) RunAndReturn(run func(*entity.Config)) *Node_SetC
 func NewNode(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Node {
+}) *Node {
 	mock := &Node{}
 	mock.Mock.Test(t)
 

--- a/mocks/Page.go
+++ b/mocks/Page.go
@@ -330,8 +330,7 @@ func (_c *Page_SetNumber_Call) RunAndReturn(run func(int, int)) *Page_SetNumber_
 func NewPage(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Page {
+}) *Page {
 	mock := &Page{}
 	mock.Mock.Test(t)
 

--- a/mocks/Provider.go
+++ b/mocks/Provider.go
@@ -581,8 +581,7 @@ func (_c *Provider_SetProtection_Call) RunAndReturn(run func(*entity.Protection)
 func NewProvider(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Provider {
+}) *Provider {
 	mock := &Provider{}
 	mock.Mock.Test(t)
 

--- a/mocks/Repository.go
+++ b/mocks/Repository.go
@@ -44,11 +44,6 @@ func (_m *Repository) AddUTF8Font(family string, style fontstyle.Type, file stri
 	return r0
 }
 
-func (_m *Repository) AddUTF8FontFromBytes(family string, style fontstyle.Type, bytes []byte) repository.Repository {
-	var r0 repository.Repository
-	return r0
-}
-
 // Repository_AddUTF8Font_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddUTF8Font'
 type Repository_AddUTF8Font_Call struct {
 	*mock.Call
@@ -75,6 +70,56 @@ func (_c *Repository_AddUTF8Font_Call) Return(_a0 repository.Repository) *Reposi
 }
 
 func (_c *Repository_AddUTF8Font_Call) RunAndReturn(run func(string, fontstyle.Type, string) repository.Repository) *Repository_AddUTF8Font_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AddUTF8FontFromBytes provides a mock function with given fields: family, style, bytes
+func (_m *Repository) AddUTF8FontFromBytes(family string, style fontstyle.Type, bytes []byte) repository.Repository {
+	ret := _m.Called(family, style, bytes)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddUTF8FontFromBytes")
+	}
+
+	var r0 repository.Repository
+	if rf, ok := ret.Get(0).(func(string, fontstyle.Type, []byte) repository.Repository); ok {
+		r0 = rf(family, style, bytes)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(repository.Repository)
+		}
+	}
+
+	return r0
+}
+
+// Repository_AddUTF8FontFromBytes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddUTF8FontFromBytes'
+type Repository_AddUTF8FontFromBytes_Call struct {
+	*mock.Call
+}
+
+// AddUTF8FontFromBytes is a helper method to define mock.On call
+//   - family string
+//   - style fontstyle.Type
+//   - bytes []byte
+func (_e *Repository_Expecter) AddUTF8FontFromBytes(family interface{}, style interface{}, bytes interface{}) *Repository_AddUTF8FontFromBytes_Call {
+	return &Repository_AddUTF8FontFromBytes_Call{Call: _e.mock.On("AddUTF8FontFromBytes", family, style, bytes)}
+}
+
+func (_c *Repository_AddUTF8FontFromBytes_Call) Run(run func(family string, style fontstyle.Type, bytes []byte)) *Repository_AddUTF8FontFromBytes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(fontstyle.Type), args[2].([]byte))
+	})
+	return _c
+}
+
+func (_c *Repository_AddUTF8FontFromBytes_Call) Return(_a0 repository.Repository) *Repository_AddUTF8FontFromBytes_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Repository_AddUTF8FontFromBytes_Call) RunAndReturn(run func(string, fontstyle.Type, []byte) repository.Repository) *Repository_AddUTF8FontFromBytes_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -141,8 +186,7 @@ func (_c *Repository_Load_Call) RunAndReturn(run func() ([]*entity.CustomFont, e
 func NewRepository(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Repository {
+}) *Repository {
 	mock := &Repository{}
 	mock.Mock.Test(t)
 

--- a/mocks/Row.go
+++ b/mocks/Row.go
@@ -346,8 +346,7 @@ func (_c *Row_WithStyle_Call) RunAndReturn(run func(*props.Cell) core.Row) *Row_
 func NewRow(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Row {
+}) *Row {
 	mock := &Row{}
 	mock.Mock.Test(t)
 

--- a/mocks/Text.go
+++ b/mocks/Text.go
@@ -110,8 +110,7 @@ func (_c *Text_GetLinesQuantity_Call) RunAndReturn(run func(string, props.Text, 
 func NewText(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *Text {
+}) *Text {
 	mock := &Text{}
 	mock.Mock.Test(t)
 

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -16,6 +16,7 @@ type Maroto interface {
 	AddRows(rows ...Row)
 	AddRow(rowHeight float64, cols ...Col) Row
 	FitlnCurrentPage(heightNewLine float64) bool
+	GetCurrentConfig() *entity.Config
 	AddPages(pages ...Page)
 	GetStructure() *node.Node[Structure]
 	Generate() (Document, error)


### PR DESCRIPTION
**Description**
Add method to core.maroto to return current pdf settings

**Related Issue**
#438 

**Checklist**
> check with "x", **ONLY IF APPLIED** to your change

- [x] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [x] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [ ] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/doc.go and docs/* <!-- If applied -->
- [x] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] Executed `make examples` to update all examples inside docs/examples. <!-- If applied -->
- [x] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [ ] Executed `make dod` with none issues pointed out by `golangci-lint`