### PR TITLE
Add align type Justify to texts

### DIFF
--- a/docs/assets/examples/textgrid/v2/main.go
+++ b/docs/assets/examples/textgrid/v2/main.go
@@ -53,33 +53,37 @@ func GetMaroto() core.Maroto {
 	)
 
 	m.AddRow(40,
-		text.NewCol(2, "Left-aligned text"),
-		text.NewCol(4, "Centered text", props.Text{Align: align.Center}),
-		text.NewCol(6, "Right-aligned text", props.Text{Align: align.Right}),
+		text.NewCol(3, "Left-aligned text"),
+		text.NewCol(3, "Centered text", props.Text{Align: align.Center}),
+		text.NewCol(3, "Right-aligned text", props.Text{Align: align.Right}),
+		text.NewCol(3, "Justify-aligned text", props.Text{Align: align.Justify}),
 	)
 
 	m.AddRows(text.NewRow(10, "Aligned unindented text"))
 
 	m.AddRow(40,
-		text.NewCol(2, "Left-aligned text", props.Text{Top: 3, Left: 3, Align: align.Left}),
-		text.NewCol(4, "Centered text", props.Text{Top: 3, Align: align.Center}),
-		text.NewCol(6, "Right-aligned text", props.Text{Top: 3, Right: 3, Align: align.Right}),
+		text.NewCol(3, "Left-aligned text", props.Text{Top: 3, Left: 3, Align: align.Left}),
+		text.NewCol(3, "Centered text", props.Text{Top: 3, Align: align.Center}),
+		text.NewCol(3, "Right-aligned text", props.Text{Top: 3, Right: 3, Align: align.Right}),
+		text.NewCol(3, "Justify-aligned text", props.Text{Top: 3, Align: align.Justify}),
 	)
 
 	m.AddRows(text.NewRow(10, "Aligned text with indentation"))
 
 	m.AddRow(40,
-		text.NewCol(2, longText, props.Text{Align: align.Left}),
-		text.NewCol(4, longText, props.Text{Align: align.Center}),
-		text.NewCol(6, longText, props.Text{Align: align.Right}),
+		text.NewCol(3, longText, props.Text{Align: align.Left}),
+		text.NewCol(3, longText, props.Text{Align: align.Center}),
+		text.NewCol(3, longText, props.Text{Align: align.Right}),
+		text.NewCol(3, longText, props.Text{Align: align.Justify}),
 	)
 
 	m.AddRows(text.NewRow(10, "Multiline text"))
 
 	m.AddRow(40,
-		text.NewCol(2, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Left, BreakLineStrategy: breakline.DashStrategy}),
-		text.NewCol(4, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Center}),
-		text.NewCol(6, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Right}),
+		text.NewCol(3, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Left, BreakLineStrategy: breakline.DashStrategy}),
+		text.NewCol(3, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Center}),
+		text.NewCol(3, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Right}),
+		text.NewCol(3, longText+" "+longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Justify}),
 	)
 
 	m.AddRows(text.NewRow(10, "Multiline text with indentation"))

--- a/docs/assets/examples/textgrid/v2/main.go
+++ b/docs/assets/examples/textgrid/v2/main.go
@@ -53,37 +53,33 @@ func GetMaroto() core.Maroto {
 	)
 
 	m.AddRow(40,
-		text.NewCol(3, "Left-aligned text"),
-		text.NewCol(3, "Centered text", props.Text{Align: align.Center}),
-		text.NewCol(3, "Right-aligned text", props.Text{Align: align.Right}),
-		text.NewCol(3, "Justify-aligned text", props.Text{Align: align.Justify}),
+		text.NewCol(2, "Left-aligned text"),
+		text.NewCol(4, "Centered text", props.Text{Align: align.Center}),
+		text.NewCol(6, "Right-aligned text", props.Text{Align: align.Right}),
 	)
 
 	m.AddRows(text.NewRow(10, "Aligned unindented text"))
 
 	m.AddRow(40,
-		text.NewCol(3, "Left-aligned text", props.Text{Top: 3, Left: 3, Align: align.Left}),
-		text.NewCol(3, "Centered text", props.Text{Top: 3, Align: align.Center}),
-		text.NewCol(3, "Right-aligned text", props.Text{Top: 3, Right: 3, Align: align.Right}),
-		text.NewCol(3, "Justify-aligned text", props.Text{Top: 3, Align: align.Justify}),
+		text.NewCol(2, "Left-aligned text", props.Text{Top: 3, Left: 3, Align: align.Left}),
+		text.NewCol(4, "Centered text", props.Text{Top: 3, Align: align.Center}),
+		text.NewCol(6, "Right-aligned text", props.Text{Top: 3, Right: 3, Align: align.Right}),
 	)
 
 	m.AddRows(text.NewRow(10, "Aligned text with indentation"))
 
 	m.AddRow(40,
-		text.NewCol(3, longText, props.Text{Align: align.Left}),
-		text.NewCol(3, longText, props.Text{Align: align.Center}),
-		text.NewCol(3, longText, props.Text{Align: align.Right}),
-		text.NewCol(3, longText, props.Text{Align: align.Justify}),
+		text.NewCol(2, longText, props.Text{Align: align.Left}),
+		text.NewCol(4, longText, props.Text{Align: align.Center}),
+		text.NewCol(6, longText, props.Text{Align: align.Right}),
 	)
 
 	m.AddRows(text.NewRow(10, "Multiline text"))
 
 	m.AddRow(40,
-		text.NewCol(3, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Left, BreakLineStrategy: breakline.DashStrategy}),
-		text.NewCol(3, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Center}),
-		text.NewCol(3, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Right}),
-		text.NewCol(3, longText+" "+longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Justify}),
+		text.NewCol(2, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Left, BreakLineStrategy: breakline.DashStrategy}),
+		text.NewCol(4, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Center}),
+		text.NewCol(6, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Right}),
 	)
 
 	m.AddRows(text.NewRow(10, "Multiline text with indentation"))
@@ -91,6 +87,13 @@ func GetMaroto() core.Maroto {
 	google := "https://google.com"
 
 	m.AddRows(text.NewRow(10, "text with hyperlink", props.Text{Hyperlink: &google}))
+
+	m.AddRow(45,
+		text.NewCol(2, longText, props.Text{Top: 3, Left: 3, Right: 3, Align: align.Justify, BreakLineStrategy: breakline.DashStrategy}),
+		text.NewCol(4, longText+" "+longText, props.Text{Top: 10, Left: 3, Right: 3, Align: align.Justify}),
+		text.NewCol(6, longText+" "+longText, props.Text{Hyperlink: &google, Top: 10, Left: 10, Right: 10, Align: align.Justify}),
+	)
+	m.AddRows(text.NewRow(10, "Justify-aligned text", props.Text{Align: align.Justify}))
 
 	return m
 }

--- a/docs/assets/pdf/textgridv2.pdf
+++ b/docs/assets/pdf/textgridv2.pdf
@@ -7,7 +7,7 @@
 /Contents 4 0 R>>
 endobj
 4 0 obj
-<</Length 7684>>
+<</Length 11418>>
 stream
 0 J
 0 j
@@ -30,123 +30,217 @@ BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 q 0.000 0.000 1.000 rg BT 387.40 803.54 Td (Blue text) Tj ET Q
-28.35 700.16 89.76 -113.39 re S 
+28.35 700.16 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 28.35 690.16 Td (Left-aligned text) Tj ET
-118.11 700.16 179.53 -113.39 re S 
+162.99 700.16 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 177.86 690.16 Td (Centered text) Tj ET
-297.64 700.16 269.29 -113.39 re S 
+BT 200.30 690.16 Td (Centered text) Tj ET
+297.64 700.16 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 489.12 690.16 Td (Right-aligned text) Tj ET
+BT 354.47 690.16 Td (Right-aligned text) Tj ET
+432.28 700.16 134.65 -113.39 re S 
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 432.28 690.16 Td (Justify-aligned) Tj ET
+BT 550.81 690.16 Td (text) Tj ET
 28.35 586.77 538.58 -28.35 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 28.35 576.77 Td (Aligned unindented text) Tj ET
-28.35 558.43 89.76 -113.39 re S 
+28.35 558.43 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 36.85 539.92 Td (Left-aligned text) Tj ET
-118.11 558.43 179.53 -113.39 re S 
+162.99 558.43 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 177.86 539.92 Td (Centered text) Tj ET
-297.64 558.43 269.29 -113.39 re S 
+BT 200.30 539.92 Td (Centered text) Tj ET
+297.64 558.43 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 480.62 539.92 Td (Right-aligned text) Tj ET
+BT 345.97 539.92 Td (Right-aligned text) Tj ET
+432.28 558.43 134.65 -113.39 re S 
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 432.28 539.92 Td (Justify-aligned) Tj ET
+BT 550.81 539.92 Td (text) Tj ET
 28.35 445.04 538.58 -28.35 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 28.35 435.04 Td (Aligned text with indentation) Tj ET
-28.35 416.69 89.76 -113.39 re S 
+28.35 416.69 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 406.69 Td (This is a longer ) Tj ET
+BT 28.35 406.69 Td (This is a longer sentence that ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 396.69 Td (sentence that will ) Tj ET
+BT 28.35 396.69 Td (will be broken into multiple ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 386.69 Td (be broken into ) Tj ET
+BT 28.35 386.69 Td (lines as it does not fit into the ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 376.69 Td (multiple lines as it ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 366.69 Td (does not fit into the ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 356.69 Td (column otherwise. ) Tj ET
-118.11 416.69 179.53 -113.39 re S 
+BT 28.35 376.69 Td (column otherwise. ) Tj ET
+162.99 416.69 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 125.89 406.69 Td (This is a longer sentence that will be ) Tj ET
+BT 163.61 406.69 Td (This is a longer sentence that ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 120.33 396.69 Td (broken into multiple lines as it does not ) Tj ET
+BT 170.29 396.69 Td (will be broken into multiple ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 143.12 386.69 Td (fit into the column otherwise. ) Tj ET
-297.64 416.69 269.29 -113.39 re S 
+BT 164.44 386.69 Td (lines as it does not fit into the ) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 188.63 376.69 Td (column otherwise. ) Tj ET
+297.64 416.69 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 313.49 406.69 Td (This is a longer sentence that will be broken into multiple ) Tj ET
+BT 298.88 406.69 Td (This is a longer sentence that ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 351.83 396.69 Td (lines as it does not fit into the column otherwise. ) Tj ET
+BT 312.24 396.69 Td (will be broken into multiple ) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 300.54 386.69 Td (lines as it does not fit into the ) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 348.92 376.69 Td (column otherwise. ) Tj ET
+432.28 416.69 134.65 -113.39 re S 
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 432.28 406.69 Td (This) Tj ET
+BT 454.76 406.69 Td (is) Tj ET
+BT 465.56 406.69 Td (a) Tj ET
+BT 474.71 406.69 Td (longer) Tj ET
+BT 506.08 406.69 Td (sentence) Tj ET
+BT 550.25 406.69 Td (that) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 432.28 396.69 Td (will) Tj ET
+BT 453.29 396.69 Td (be) Tj ET
+BT 471.54 396.69 Td (broken) Tj ET
+BT 509.23 396.69 Td (into) Tj ET
+BT 532.48 396.69 Td (multiple) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 432.28 386.69 Td (lines) Tj ET
+BT 456.44 386.69 Td (as) Tj ET
+BT 470.59 386.69 Td (it) Tj ET
+BT 479.18 386.69 Td (does) Tj ET
+BT 504.45 386.69 Td (not) Tj ET
+BT 521.94 386.69 Td (fit) Tj ET
+BT 533.32 386.69 Td (into) Tj ET
+BT 553.03 386.69 Td (the) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 432.28 376.69 Td (column) Tj ET
+BT 467.29 376.69 Td (otherwise.) Tj ET
 28.35 303.31 538.58 -28.35 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 28.35 293.31 Td (Multiline text) Tj ET
-28.35 274.96 89.76 -113.39 re S 
+28.35 274.96 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 256.46 Td (This is a long-) Tj ET
+BT 36.85 256.46 Td (This is a longer senten-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 246.46 Td (er sentence -) Tj ET
+BT 36.85 246.46 Td (ce that will be broken in-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 236.46 Td (that will be b-) Tj ET
+BT 36.85 236.46 Td (to multiple lines as it do-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 226.46 Td (roken into m-) Tj ET
+BT 36.85 226.46 Td (es not fit into the colum-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 216.46 Td (ultiple lines a-) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 206.46 Td (s it does not -) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 196.46 Td (fit into the co-) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 186.46 Td (lumn otherwi-) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 176.46 Td (se.) Tj ET
-118.11 274.96 179.53 -113.39 re S 
+BT 36.85 216.46 Td (n otherwise.) Tj ET
+162.99 274.96 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 132.84 256.46 Td (This is a longer sentence that will ) Tj ET
+BT 173.34 256.46 Td (This is a longer sentence ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 133.95 246.46 Td (be broken into multiple lines as it ) Tj ET
+BT 179.18 246.46 Td (that will be broken into ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 146.73 236.46 Td (does not fit into the column ) Tj ET
+BT 177.24 236.46 Td (multiple lines as it does ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 183.70 226.46 Td (otherwise. ) Tj ET
-297.64 274.96 269.29 -113.39 re S 
+BT 181.40 226.46 Td (not fit into the column ) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 206.14 216.46 Td (otherwise. ) Tj ET
+297.64 274.96 134.65 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 342.22 256.46 Td (This is a longer sentence that will be broken into ) Tj ET
+BT 309.84 256.46 Td (This is a longer sentence ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 354.45 246.46 Td (multiple lines as it does not fit into the column ) Tj ET
+BT 321.51 246.46 Td (that will be broken into ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 510.08 236.46 Td (otherwise. ) Tj ET
+BT 317.63 236.46 Td (multiple lines as it does ) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 325.95 226.46 Td (not fit into the column ) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 375.43 216.46 Td (otherwise. ) Tj ET
+432.28 274.96 134.65 -113.39 re S 
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 440.79 256.46 Td (This) Tj ET
+BT 464.08 256.46 Td (is) Tj ET
+BT 475.70 256.46 Td (a) Tj ET
+BT 485.66 256.46 Td (longer) Tj ET
+BT 517.85 256.46 Td (sentence) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 440.79 246.46 Td (that) Tj ET
+BT 464.78 246.46 Td (will) Tj ET
+BT 485.98 246.46 Td (be) Tj ET
+BT 504.42 246.46 Td (broken) Tj ET
+BT 542.31 246.46 Td (into) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 440.79 236.46 Td (multiple) Tj ET
+BT 481.58 236.46 Td (lines) Tj ET
+BT 508.49 236.46 Td (as) Tj ET
+BT 525.40 236.46 Td (it) Tj ET
+BT 536.75 236.46 Td (does) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 440.79 226.46 Td (not) Tj ET
+BT 463.11 226.46 Td (fit) Tj ET
+BT 479.32 226.46 Td (into) Tj ET
+BT 503.87 226.46 Td (the) Tj ET
+BT 526.20 226.46 Td (column) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 440.79 216.46 Td (otherwise.) Tj ET
+BT 499.82 216.46 Td (This) Tj ET
+BT 532.18 216.46 Td (is) Tj ET
+BT 552.87 216.46 Td (a) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 440.79 206.46 Td (longer) Tj ET
+BT 474.81 206.46 Td (sentence) Tj ET
+BT 521.63 206.46 Td (that) Tj ET
+BT 544.55 206.46 Td (will) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 440.79 196.46 Td (be) Tj ET
+BT 460.37 196.46 Td (broken) Tj ET
+BT 499.40 196.46 Td (into) Tj ET
+BT 523.98 196.46 Td (multiple) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 440.79 186.46 Td (lines) Tj ET
+BT 465.02 186.46 Td (as) Tj ET
+BT 479.25 186.46 Td (it) Tj ET
+BT 487.93 186.46 Td (does) Tj ET
+BT 513.28 186.46 Td (not) Tj ET
+BT 530.85 186.46 Td (fit) Tj ET
+BT 542.31 186.46 Td (into) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 440.79 176.46 Td (the) Tj ET
+BT 467.66 176.46 Td (column) Tj ET
+BT 512.86 176.46 Td (otherwise.) Tj ET
 28.35 161.57 538.58 -28.35 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
@@ -190,8 +284,8 @@ endobj
 6 0 obj
 <<
 /Producer (þÿ F P D F   1 . 7)
-/CreationDate (D:20240520221140)
-/ModDate (D:20240520221140)
+/CreationDate (D:20240621183457)
+/ModDate (D:20240621183457)
 >>
 endobj
 7 0 obj
@@ -208,13 +302,13 @@ endobj
 xref
 0 8
 0000000000 65535 f 
-0000007955 00000 n 
-0000008138 00000 n 
+0000011690 00000 n 
+0000011873 00000 n 
 0000000009 00000 n 
 0000000221 00000 n 
-0000008042 00000 n 
-0000008299 00000 n 
-0000008412 00000 n 
+0000011777 00000 n 
+0000012034 00000 n 
+0000012147 00000 n 
 trailer
 <<
 /Size 8
@@ -222,5 +316,5 @@ trailer
 /Info 6 0 R
 >>
 startxref
-8509
+12244
 %%EOF

--- a/docs/assets/pdf/textgridv2.pdf
+++ b/docs/assets/pdf/textgridv2.pdf
@@ -7,7 +7,7 @@
 /Contents 4 0 R>>
 endobj
 4 0 obj
-<</Length 11418>>
+<</Length 7684>>
 stream
 0 J
 0 j
@@ -30,217 +30,123 @@ BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 q 0.000 0.000 1.000 rg BT 387.40 803.54 Td (Blue text) Tj ET Q
-28.35 700.16 134.65 -113.39 re S 
+28.35 700.16 89.76 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 28.35 690.16 Td (Left-aligned text) Tj ET
-162.99 700.16 134.65 -113.39 re S 
+118.11 700.16 179.53 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 200.30 690.16 Td (Centered text) Tj ET
-297.64 700.16 134.65 -113.39 re S 
+BT 177.86 690.16 Td (Centered text) Tj ET
+297.64 700.16 269.29 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 354.47 690.16 Td (Right-aligned text) Tj ET
-432.28 700.16 134.65 -113.39 re S 
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 432.28 690.16 Td (Justify-aligned) Tj ET
-BT 550.81 690.16 Td (text) Tj ET
+BT 489.12 690.16 Td (Right-aligned text) Tj ET
 28.35 586.77 538.58 -28.35 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 28.35 576.77 Td (Aligned unindented text) Tj ET
-28.35 558.43 134.65 -113.39 re S 
+28.35 558.43 89.76 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 36.85 539.92 Td (Left-aligned text) Tj ET
-162.99 558.43 134.65 -113.39 re S 
+118.11 558.43 179.53 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 200.30 539.92 Td (Centered text) Tj ET
-297.64 558.43 134.65 -113.39 re S 
+BT 177.86 539.92 Td (Centered text) Tj ET
+297.64 558.43 269.29 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 345.97 539.92 Td (Right-aligned text) Tj ET
-432.28 558.43 134.65 -113.39 re S 
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 432.28 539.92 Td (Justify-aligned) Tj ET
-BT 550.81 539.92 Td (text) Tj ET
+BT 480.62 539.92 Td (Right-aligned text) Tj ET
 28.35 445.04 538.58 -28.35 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 28.35 435.04 Td (Aligned text with indentation) Tj ET
-28.35 416.69 134.65 -113.39 re S 
+28.35 416.69 89.76 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 406.69 Td (This is a longer sentence that ) Tj ET
+BT 28.35 406.69 Td (This is a longer ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 396.69 Td (will be broken into multiple ) Tj ET
+BT 28.35 396.69 Td (sentence that will ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 386.69 Td (lines as it does not fit into the ) Tj ET
+BT 28.35 386.69 Td (be broken into ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 28.35 376.69 Td (column otherwise. ) Tj ET
-162.99 416.69 134.65 -113.39 re S 
+BT 28.35 376.69 Td (multiple lines as it ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 28.35 366.69 Td (does not fit into the ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 163.61 406.69 Td (This is a longer sentence that ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 170.29 396.69 Td (will be broken into multiple ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 164.44 386.69 Td (lines as it does not fit into the ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 188.63 376.69 Td (column otherwise. ) Tj ET
-297.64 416.69 134.65 -113.39 re S 
+BT 28.35 356.69 Td (column otherwise. ) Tj ET
+118.11 416.69 179.53 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 298.88 406.69 Td (This is a longer sentence that ) Tj ET
+BT 125.89 406.69 Td (This is a longer sentence that will be ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 312.24 396.69 Td (will be broken into multiple ) Tj ET
+BT 120.33 396.69 Td (broken into multiple lines as it does not ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 300.54 386.69 Td (lines as it does not fit into the ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 348.92 376.69 Td (column otherwise. ) Tj ET
-432.28 416.69 134.65 -113.39 re S 
+BT 143.12 386.69 Td (fit into the column otherwise. ) Tj ET
+297.64 416.69 269.29 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 432.28 406.69 Td (This) Tj ET
-BT 454.76 406.69 Td (is) Tj ET
-BT 465.56 406.69 Td (a) Tj ET
-BT 474.71 406.69 Td (longer) Tj ET
-BT 506.08 406.69 Td (sentence) Tj ET
-BT 550.25 406.69 Td (that) Tj ET
+BT 313.49 406.69 Td (This is a longer sentence that will be broken into multiple ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 432.28 396.69 Td (will) Tj ET
-BT 453.29 396.69 Td (be) Tj ET
-BT 471.54 396.69 Td (broken) Tj ET
-BT 509.23 396.69 Td (into) Tj ET
-BT 532.48 396.69 Td (multiple) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 432.28 386.69 Td (lines) Tj ET
-BT 456.44 386.69 Td (as) Tj ET
-BT 470.59 386.69 Td (it) Tj ET
-BT 479.18 386.69 Td (does) Tj ET
-BT 504.45 386.69 Td (not) Tj ET
-BT 521.94 386.69 Td (fit) Tj ET
-BT 533.32 386.69 Td (into) Tj ET
-BT 553.03 386.69 Td (the) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 432.28 376.69 Td (column) Tj ET
-BT 467.29 376.69 Td (otherwise.) Tj ET
+BT 351.83 396.69 Td (lines as it does not fit into the column otherwise. ) Tj ET
 28.35 303.31 538.58 -28.35 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT 28.35 293.31 Td (Multiline text) Tj ET
-28.35 274.96 134.65 -113.39 re S 
+28.35 274.96 89.76 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 256.46 Td (This is a longer senten-) Tj ET
+BT 36.85 256.46 Td (This is a long-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 246.46 Td (ce that will be broken in-) Tj ET
+BT 36.85 246.46 Td (er sentence -) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 236.46 Td (to multiple lines as it do-) Tj ET
+BT 36.85 236.46 Td (that will be b-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 226.46 Td (es not fit into the colum-) Tj ET
+BT 36.85 226.46 Td (roken into m-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 36.85 216.46 Td (n otherwise.) Tj ET
-162.99 274.96 134.65 -113.39 re S 
+BT 36.85 216.46 Td (ultiple lines a-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 206.46 Td (s it does not -) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 196.46 Td (fit into the co-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 173.34 256.46 Td (This is a longer sentence ) Tj ET
+BT 36.85 186.46 Td (lumn otherwi-) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 179.18 246.46 Td (that will be broken into ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 177.24 236.46 Td (multiple lines as it does ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 181.40 226.46 Td (not fit into the column ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 206.14 216.46 Td (otherwise. ) Tj ET
-297.64 274.96 134.65 -113.39 re S 
+BT 36.85 176.46 Td (se.) Tj ET
+118.11 274.96 179.53 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 309.84 256.46 Td (This is a longer sentence ) Tj ET
+BT 132.84 256.46 Td (This is a longer sentence that will ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 321.51 246.46 Td (that will be broken into ) Tj ET
+BT 133.95 246.46 Td (be broken into multiple lines as it ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 317.63 236.46 Td (multiple lines as it does ) Tj ET
+BT 146.73 236.46 Td (does not fit into the column ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 325.95 226.46 Td (not fit into the column ) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 375.43 216.46 Td (otherwise. ) Tj ET
-432.28 274.96 134.65 -113.39 re S 
+BT 183.70 226.46 Td (otherwise. ) Tj ET
+297.64 274.96 269.29 -113.39 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 440.79 256.46 Td (This) Tj ET
-BT 464.08 256.46 Td (is) Tj ET
-BT 475.70 256.46 Td (a) Tj ET
-BT 485.66 256.46 Td (longer) Tj ET
-BT 517.85 256.46 Td (sentence) Tj ET
+BT 342.22 256.46 Td (This is a longer sentence that will be broken into ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 440.79 246.46 Td (that) Tj ET
-BT 464.78 246.46 Td (will) Tj ET
-BT 485.98 246.46 Td (be) Tj ET
-BT 504.42 246.46 Td (broken) Tj ET
-BT 542.31 246.46 Td (into) Tj ET
+BT 354.45 246.46 Td (multiple lines as it does not fit into the column ) Tj ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 440.79 236.46 Td (multiple) Tj ET
-BT 481.58 236.46 Td (lines) Tj ET
-BT 508.49 236.46 Td (as) Tj ET
-BT 525.40 236.46 Td (it) Tj ET
-BT 536.75 236.46 Td (does) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 440.79 226.46 Td (not) Tj ET
-BT 463.11 226.46 Td (fit) Tj ET
-BT 479.32 226.46 Td (into) Tj ET
-BT 503.87 226.46 Td (the) Tj ET
-BT 526.20 226.46 Td (column) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 440.79 216.46 Td (otherwise.) Tj ET
-BT 499.82 216.46 Td (This) Tj ET
-BT 532.18 216.46 Td (is) Tj ET
-BT 552.87 216.46 Td (a) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 440.79 206.46 Td (longer) Tj ET
-BT 474.81 206.46 Td (sentence) Tj ET
-BT 521.63 206.46 Td (that) Tj ET
-BT 544.55 206.46 Td (will) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 440.79 196.46 Td (be) Tj ET
-BT 460.37 196.46 Td (broken) Tj ET
-BT 499.40 196.46 Td (into) Tj ET
-BT 523.98 196.46 Td (multiple) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 440.79 186.46 Td (lines) Tj ET
-BT 465.02 186.46 Td (as) Tj ET
-BT 479.25 186.46 Td (it) Tj ET
-BT 487.93 186.46 Td (does) Tj ET
-BT 513.28 186.46 Td (not) Tj ET
-BT 530.85 186.46 Td (fit) Tj ET
-BT 542.31 186.46 Td (into) Tj ET
-BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
-BT 440.79 176.46 Td (the) Tj ET
-BT 467.66 176.46 Td (column) Tj ET
-BT 512.86 176.46 Td (otherwise.) Tj ET
+BT 510.08 236.46 Td (otherwise. ) Tj ET
 28.35 161.57 538.58 -28.35 re S 
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
@@ -255,14 +161,184 @@ q 0.000 0.000 1.000 rg BT 28.35 123.23 Td (text with hyperlink) Tj ET Q
 
 endstream
 endobj
+5 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Annots [<</Type /Annot /Subtype /Link /Rect [325.98 785.20 538.58 775.20] /Border [0 0 0] /A <</S /URI /URI (https://google.com)>>>><</Type /Annot /Subtype /Link /Rect [325.98 775.20 538.58 765.20] /Border [0 0 0] /A <</S /URI /URI (https://google.com)>>>><</Type /Annot /Subtype /Link /Rect [325.98 765.20 538.58 755.20] /Border [0 0 0] /A <</S /URI /URI (https://google.com)>>>><</Type /Annot /Subtype /Link /Rect [325.98 755.20 538.58 745.20] /Border [0 0 0] /A <</S /URI /URI (https://google.com)>>>><</Type /Annot /Subtype /Link /Rect [325.98 745.20 538.58 735.20] /Border [0 0 0] /A <</S /URI /URI (https://google.com)>>>>]
+/Contents 6 0 R>>
+endobj
+6 0 obj
+<</Length 6898>>
+stream
+0 J
+0 j
+0.57 w
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+0.000 G
+0.000 g
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+28.35 813.54 89.76 -127.56 re S 
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 795.04 Td (This) Tj ET
+BT 62.03 795.04 Td (is) Tj ET
+BT 75.53 795.04 Td (a) Tj ET
+BT 87.38 795.04 Td (long-) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 785.04 Td (er) Tj ET
+BT 55.72 785.04 Td (sentence) Tj ET
+BT 106.28 785.04 Td (-) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 775.04 Td (that) Tj ET
+BT 60.93 775.04 Td (will) Tj ET
+BT 82.20 775.04 Td (be) Tj ET
+BT 100.72 775.04 Td (b-) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 765.04 Td (roken) Tj ET
+BT 71.84 765.04 Td (into) Tj ET
+BT 97.95 765.04 Td (m-) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 755.04 Td (ultiple) Tj ET
+BT 71.56 755.04 Td (lines) Tj ET
+BT 100.72 755.04 Td (a-) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 745.04 Td (s) Tj ET
+BT 47.81 745.04 Td (it) Tj ET
+BT 58.77 745.04 Td (does) Tj ET
+BT 86.41 745.04 Td (not) Tj ET
+BT 106.28 745.04 Td (-) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 735.04 Td (fit) Tj ET
+BT 51.65 735.04 Td (into) Tj ET
+BT 74.79 735.04 Td (the) Tj ET
+BT 95.72 735.04 Td (co-) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 725.04 Td (lumn) Tj ET
+BT 74.05 725.04 Td (otherwi-) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 715.04 Td (se.) Tj ET
+118.11 813.54 179.53 -127.56 re S 
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 126.61 775.20 Td (This) Tj ET
+BT 150.82 775.20 Td (is) Tj ET
+BT 163.36 775.20 Td (a) Tj ET
+BT 174.24 775.20 Td (longer) Tj ET
+BT 207.35 775.20 Td (sentence) Tj ET
+BT 253.25 775.20 Td (that) Tj ET
+BT 275.25 775.20 Td (will) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 126.61 765.20 Td (be) Tj ET
+BT 143.42 765.20 Td (broken) Tj ET
+BT 179.68 765.20 Td (into) Tj ET
+BT 201.49 765.20 Td (multiple) Tj ET
+BT 241.63 765.20 Td (lines) Tj ET
+BT 267.88 765.20 Td (as) Tj ET
+BT 284.13 765.20 Td (it) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 126.61 755.20 Td (does) Tj ET
+BT 159.68 755.20 Td (not) Tj ET
+BT 184.96 755.20 Td (fit) Tj ET
+BT 204.12 755.20 Td (into) Tj ET
+BT 231.62 755.20 Td (the) Tj ET
+BT 256.90 755.20 Td (column) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 126.61 745.20 Td (otherwise.) Tj ET
+BT 175.57 745.20 Td (This) Tj ET
+BT 197.84 745.20 Td (is) Tj ET
+BT 208.44 745.20 Td (a) Tj ET
+BT 217.38 745.20 Td (longer) Tj ET
+BT 248.55 745.20 Td (sentence) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 126.61 735.20 Td (that) Tj ET
+BT 151.23 735.20 Td (will) Tj ET
+BT 173.05 735.20 Td (be) Tj ET
+BT 192.11 735.20 Td (broken) Tj ET
+BT 230.62 735.20 Td (into) Tj ET
+BT 254.68 735.20 Td (multiple) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 126.61 725.20 Td (lines) Tj ET
+BT 154.75 725.20 Td (as) Tj ET
+BT 172.88 725.20 Td (it) Tj ET
+BT 185.46 725.20 Td (does) Tj ET
+BT 214.71 725.20 Td (not) Tj ET
+BT 236.19 725.20 Td (fit) Tj ET
+BT 251.54 725.20 Td (into) Tj ET
+BT 275.23 725.20 Td (the) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 126.61 715.20 Td (column) Tj ET
+BT 161.62 715.20 Td (otherwise.) Tj ET
+297.64 813.54 269.29 -127.56 re S 
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+q 0.000 0.000 1.000 rg BT 325.98 775.20 Td (This) Tj ET Q
+q 0.000 0.000 1.000 rg BT 349.91 775.20 Td (is) Tj ET Q
+q 0.000 0.000 1.000 rg BT 362.17 775.20 Td (a) Tj ET Q
+q 0.000 0.000 1.000 rg BT 372.77 775.20 Td (longer) Tj ET Q
+q 0.000 0.000 1.000 rg BT 405.60 775.20 Td (sentence) Tj ET Q
+q 0.000 0.000 1.000 rg BT 451.22 775.20 Td (that) Tj ET Q
+q 0.000 0.000 1.000 rg BT 472.94 775.20 Td (will) Tj ET Q
+q 0.000 0.000 1.000 rg BT 491.85 775.20 Td (be) Tj ET Q
+q 0.000 0.000 1.000 rg BT 508.01 775.20 Td (broken) Tj ET Q
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+q 0.000 0.000 1.000 rg BT 325.98 765.20 Td (into) Tj ET Q
+q 0.000 0.000 1.000 rg BT 347.94 765.20 Td (multiple) Tj ET Q
+q 0.000 0.000 1.000 rg BT 388.23 765.20 Td (lines) Tj ET Q
+q 0.000 0.000 1.000 rg BT 414.62 765.20 Td (as) Tj ET Q
+q 0.000 0.000 1.000 rg BT 431.02 765.20 Td (it) Tj ET Q
+q 0.000 0.000 1.000 rg BT 441.86 765.20 Td (does) Tj ET Q
+q 0.000 0.000 1.000 rg BT 469.37 765.20 Td (not) Tj ET Q
+q 0.000 0.000 1.000 rg BT 489.11 765.20 Td (fit) Tj ET Q
+q 0.000 0.000 1.000 rg BT 502.73 765.20 Td (into) Tj ET Q
+q 0.000 0.000 1.000 rg BT 524.68 765.20 Td (the) Tj ET Q
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+q 0.000 0.000 1.000 rg BT 325.98 755.20 Td (column) Tj ET Q
+q 0.000 0.000 1.000 rg BT 364.01 755.20 Td (otherwise.) Tj ET Q
+q 0.000 0.000 1.000 rg BT 415.37 755.20 Td (This) Tj ET Q
+q 0.000 0.000 1.000 rg BT 440.05 755.20 Td (is) Tj ET Q
+q 0.000 0.000 1.000 rg BT 453.07 755.20 Td (a) Tj ET Q
+q 0.000 0.000 1.000 rg BT 464.42 755.20 Td (longer) Tj ET Q
+q 0.000 0.000 1.000 rg BT 498.00 755.20 Td (sentence) Tj ET Q
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+q 0.000 0.000 1.000 rg BT 325.98 745.20 Td (that) Tj ET Q
+q 0.000 0.000 1.000 rg BT 346.22 745.20 Td (will) Tj ET Q
+q 0.000 0.000 1.000 rg BT 363.65 745.20 Td (be) Tj ET Q
+q 0.000 0.000 1.000 rg BT 378.32 745.20 Td (broken) Tj ET Q
+q 0.000 0.000 1.000 rg BT 412.45 745.20 Td (into) Tj ET Q
+q 0.000 0.000 1.000 rg BT 432.12 745.20 Td (multiple) Tj ET Q
+q 0.000 0.000 1.000 rg BT 470.12 745.20 Td (lines) Tj ET Q
+q 0.000 0.000 1.000 rg BT 494.24 745.20 Td (as) Tj ET Q
+q 0.000 0.000 1.000 rg BT 508.35 745.20 Td (it) Tj ET Q
+q 0.000 0.000 1.000 rg BT 516.90 745.20 Td (does) Tj ET Q
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+q 0.000 0.000 1.000 rg BT 325.98 735.20 Td (not) Tj ET Q
+q 0.000 0.000 1.000 rg BT 356.50 735.20 Td (fit) Tj ET Q
+q 0.000 0.000 1.000 rg BT 380.90 735.20 Td (into) Tj ET Q
+q 0.000 0.000 1.000 rg BT 413.64 735.20 Td (the) Tj ET Q
+q 0.000 0.000 1.000 rg BT 444.16 735.20 Td (column) Tj ET Q
+q 0.000 0.000 1.000 rg BT 493.01 735.20 Td (otherwise.) Tj ET Q
+28.35 685.98 538.58 -28.35 re S 
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 28.35 675.98 Td (Justify-aligned) Tj ET
+BT 550.81 675.98 Td (text) Tj ET
+28.35 657.64 538.58 -600.94 re S 
+
+endstream
+endobj
 1 0 obj
 <</Type /Pages
-/Kids [3 0 R ]
-/Count 1
+/Kids [3 0 R 5 0 R ]
+/Count 2
 /MediaBox [0 0 595.28 841.89]
 >>
 endobj
-5 0 obj
+7 0 obj
 <</Type /Font
 /BaseFont /Helvetica
 /Subtype /Type1
@@ -273,7 +349,7 @@ endobj
 <<
 /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
 /Font <<
-/F0a76705d18e0494dd24cb573e53aa0a8c710ec99 5 0 R
+/F0a76705d18e0494dd24cb573e53aa0a8c710ec99 7 0 R
 >>
 /XObject <<
 >>
@@ -281,14 +357,14 @@ endobj
 >>
 >>
 endobj
-6 0 obj
+8 0 obj
 <<
 /Producer (þÿ F P D F   1 . 7)
-/CreationDate (D:20240621183457)
-/ModDate (D:20240621183457)
+/CreationDate (D:20240623174749)
+/ModDate (D:20240623174749)
 >>
 endobj
-7 0 obj
+9 0 obj
 <<
 /Type /Catalog
 /Pages 1 0 R
@@ -300,21 +376,23 @@ endobj
 >>
 endobj
 xref
-0 8
+0 10
 0000000000 65535 f 
-0000011690 00000 n 
-0000011873 00000 n 
+0000015612 00000 n 
+0000015801 00000 n 
 0000000009 00000 n 
 0000000221 00000 n 
-0000011777 00000 n 
-0000012034 00000 n 
-0000012147 00000 n 
+0000007955 00000 n 
+0000008664 00000 n 
+0000015705 00000 n 
+0000015962 00000 n 
+0000016075 00000 n 
 trailer
 <<
-/Size 8
-/Root 7 0 R
-/Info 6 0 R
+/Size 10
+/Root 9 0 R
+/Info 8 0 R
 >>
 startxref
-12244
+16172
 %%EOF

--- a/docs/assets/text/textgridv2.txt
+++ b/docs/assets/text/textgridv2.txt
@@ -1,4 +1,4 @@
-generate -> avg: 21.04ms, executions: [21.04ms]
-add_row -> avg: 675.40ns, executions: [2.01μs, 0.50μs, 0.30μs, 0.30μs, 0.26μs]
-add_rows -> avg: 260.40ns, executions: [331.00ns, 301.00ns, 100.00ns, 470.00ns, 100.00ns]
-file_size -> 8.74Kb
+generate -> avg: 19.60ms, executions: [19.60ms]
+add_row -> avg: 692.00ns, executions: [1.73μs, 0.60μs, 0.38μs, 0.34μs, 0.41μs]
+add_rows -> avg: 303.40ns, executions: [390.00ns, 332.00ns, 109.00ns, 619.00ns, 67.00ns]
+file_size -> 12.48Kb

--- a/docs/assets/text/textgridv2.txt
+++ b/docs/assets/text/textgridv2.txt
@@ -1,4 +1,4 @@
-generate -> avg: 19.60ms, executions: [19.60ms]
-add_row -> avg: 692.00ns, executions: [1.73μs, 0.60μs, 0.38μs, 0.34μs, 0.41μs]
-add_rows -> avg: 303.40ns, executions: [390.00ns, 332.00ns, 109.00ns, 619.00ns, 67.00ns]
-file_size -> 12.48Kb
+generate -> avg: 16.01ms, executions: [16.01ms]
+add_row -> avg: 755.00ns, executions: [1.49μs, 0.51μs, 0.37μs, 0.35μs, 0.33μs, 1.49μs]
+add_rows -> avg: 261.67ns, executions: [323.00ns, 322.00ns, 143.00ns, 364.00ns, 144.00ns, 274.00ns]
+file_size -> 16.45Kb

--- a/internal/providers/gofpdf/text.go
+++ b/internal/providers/gofpdf/text.go
@@ -205,10 +205,16 @@ func (s *text) addLine(textProp *props.Text, xColOffset, colWidth, yColOffset, t
 		if isIncorrectSpaceWidth(textWidth, spaceWidth, defaultSpaceWidth, textNotSpaces) {
 			spaceWidth = defaultSpaceWidth
 		}
-
+		initX := x
+		var finishX float64
 		for _, word := range words {
 			s.pdf.Text(x, yColOffset+top, word)
-			x += s.pdf.GetStringWidth(word) + spaceWidth
+			finishX = x + s.pdf.GetStringWidth(word)
+			x = finishX + spaceWidth
+		}
+
+		if textProp.Hyperlink != nil {
+			s.pdf.LinkString(initX, yColOffset+top-fontHeight, finishX-initX, fontHeight, *textProp.Hyperlink)
 		}
 
 		return

--- a/internal/providers/gofpdf/text.go
+++ b/internal/providers/gofpdf/text.go
@@ -218,7 +218,6 @@ func (s *text) addLine(textProp *props.Text, xColOffset, colWidth, yColOffset, t
 		}
 
 		return
-
 	}
 
 	var modifier float64 = 2

--- a/pkg/consts/align/align.go
+++ b/pkg/consts/align/align.go
@@ -17,7 +17,7 @@ const (
 	Bottom Type = "B"
 	// Middle represents a middle align (from gofpdf).
 	Middle Type = "M"
-	//Justify represents a horizontal alignment that distributes
-	//the text evenly between the left and right margins.
+	// Justify represents a horizontal alignment that distributes
+	// the text evenly between the left and right margins.
 	Justify = "J"
 )

--- a/pkg/consts/align/align.go
+++ b/pkg/consts/align/align.go
@@ -17,4 +17,7 @@ const (
 	Bottom Type = "B"
 	// Middle represents a middle align (from gofpdf).
 	Middle Type = "M"
+	//Justify represents a horizontal alignment that distributes
+	//the text evenly between the left and right margins.
+	Justify = "J"
 )

--- a/test/maroto/examples/textgrid.json
+++ b/test/maroto/examples/textgrid.json
@@ -70,7 +70,7 @@
 					"type": "row",
 					"nodes": [
 						{
-							"value": 2,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -80,7 +80,7 @@
 							]
 						},
 						{
-							"value": 4,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -93,7 +93,7 @@
 							]
 						},
 						{
-							"value": 6,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -101,6 +101,19 @@
 									"type": "text",
 									"details": {
 										"prop_align": "R"
+									}
+								}
+							]
+						},
+						{
+							"value": 3,
+							"type": "col",
+							"nodes": [
+								{
+									"value": "Justify-aligned text",
+									"type": "text",
+									"details": {
+										"prop_align": "J"
 									}
 								}
 							]
@@ -131,7 +144,7 @@
 					"type": "row",
 					"nodes": [
 						{
-							"value": 2,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -146,7 +159,7 @@
 							]
 						},
 						{
-							"value": 4,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -160,7 +173,7 @@
 							]
 						},
 						{
-							"value": 6,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -169,6 +182,20 @@
 									"details": {
 										"prop_align": "R",
 										"prop_right": 3,
+										"prop_top": 3
+									}
+								}
+							]
+						},
+						{
+							"value": 3,
+							"type": "col",
+							"nodes": [
+								{
+									"value": "Justify-aligned text",
+									"type": "text",
+									"details": {
+										"prop_align": "J",
 										"prop_top": 3
 									}
 								}
@@ -200,7 +227,7 @@
 					"type": "row",
 					"nodes": [
 						{
-							"value": 2,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -213,7 +240,7 @@
 							]
 						},
 						{
-							"value": 4,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -226,7 +253,7 @@
 							]
 						},
 						{
-							"value": 6,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -234,6 +261,18 @@
 									"type": "text",
 									"details": {
 										"prop_align": "R"
+									}
+								}
+							]
+						},{
+							"value": 3,
+							"type": "col",
+							"nodes": [
+								{
+									"value": "This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise.",
+									"type": "text",
+									"details": {
+										"prop_align": "J"
 									}
 								}
 							]
@@ -264,7 +303,7 @@
 					"type": "row",
 					"nodes": [
 						{
-							"value": 2,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -281,7 +320,7 @@
 							]
 						},
 						{
-							"value": 4,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -297,7 +336,7 @@
 							]
 						},
 						{
-							"value": 6,
+							"value": 3,
 							"type": "col",
 							"nodes": [
 								{
@@ -305,6 +344,21 @@
 									"type": "text",
 									"details": {
 										"prop_align": "R",
+										"prop_left": 3,
+										"prop_right": 3,
+										"prop_top": 3
+									}
+								}
+							]
+						},{
+							"value": 3,
+							"type": "col",
+							"nodes": [
+								{
+									"value": "This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise. This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise.",
+									"type": "text",
+									"details": {
+										"prop_align": "J",
 										"prop_left": 3,
 										"prop_right": 3,
 										"prop_top": 3

--- a/test/maroto/examples/textgrid.json
+++ b/test/maroto/examples/textgrid.json
@@ -70,7 +70,7 @@
 					"type": "row",
 					"nodes": [
 						{
-							"value": 3,
+							"value": 2,
 							"type": "col",
 							"nodes": [
 								{
@@ -80,7 +80,7 @@
 							]
 						},
 						{
-							"value": 3,
+							"value": 4,
 							"type": "col",
 							"nodes": [
 								{
@@ -93,7 +93,7 @@
 							]
 						},
 						{
-							"value": 3,
+							"value": 6,
 							"type": "col",
 							"nodes": [
 								{
@@ -101,19 +101,6 @@
 									"type": "text",
 									"details": {
 										"prop_align": "R"
-									}
-								}
-							]
-						},
-						{
-							"value": 3,
-							"type": "col",
-							"nodes": [
-								{
-									"value": "Justify-aligned text",
-									"type": "text",
-									"details": {
-										"prop_align": "J"
 									}
 								}
 							]
@@ -144,7 +131,7 @@
 					"type": "row",
 					"nodes": [
 						{
-							"value": 3,
+							"value": 2,
 							"type": "col",
 							"nodes": [
 								{
@@ -159,7 +146,7 @@
 							]
 						},
 						{
-							"value": 3,
+							"value": 4,
 							"type": "col",
 							"nodes": [
 								{
@@ -173,7 +160,7 @@
 							]
 						},
 						{
-							"value": 3,
+							"value": 6,
 							"type": "col",
 							"nodes": [
 								{
@@ -182,20 +169,6 @@
 									"details": {
 										"prop_align": "R",
 										"prop_right": 3,
-										"prop_top": 3
-									}
-								}
-							]
-						},
-						{
-							"value": 3,
-							"type": "col",
-							"nodes": [
-								{
-									"value": "Justify-aligned text",
-									"type": "text",
-									"details": {
-										"prop_align": "J",
 										"prop_top": 3
 									}
 								}
@@ -227,7 +200,7 @@
 					"type": "row",
 					"nodes": [
 						{
-							"value": 3,
+							"value": 2,
 							"type": "col",
 							"nodes": [
 								{
@@ -240,7 +213,7 @@
 							]
 						},
 						{
-							"value": 3,
+							"value": 4,
 							"type": "col",
 							"nodes": [
 								{
@@ -253,7 +226,7 @@
 							]
 						},
 						{
-							"value": 3,
+							"value": 6,
 							"type": "col",
 							"nodes": [
 								{
@@ -261,18 +234,6 @@
 									"type": "text",
 									"details": {
 										"prop_align": "R"
-									}
-								}
-							]
-						},{
-							"value": 3,
-							"type": "col",
-							"nodes": [
-								{
-									"value": "This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise.",
-									"type": "text",
-									"details": {
-										"prop_align": "J"
 									}
 								}
 							]
@@ -303,7 +264,7 @@
 					"type": "row",
 					"nodes": [
 						{
-							"value": 3,
+							"value": 2,
 							"type": "col",
 							"nodes": [
 								{
@@ -320,7 +281,7 @@
 							]
 						},
 						{
-							"value": 3,
+							"value": 4,
 							"type": "col",
 							"nodes": [
 								{
@@ -336,7 +297,7 @@
 							]
 						},
 						{
-							"value": 3,
+							"value": 6,
 							"type": "col",
 							"nodes": [
 								{
@@ -344,21 +305,6 @@
 									"type": "text",
 									"details": {
 										"prop_align": "R",
-										"prop_left": 3,
-										"prop_right": 3,
-										"prop_top": 3
-									}
-								}
-							]
-						},{
-							"value": 3,
-							"type": "col",
-							"nodes": [
-								{
-									"value": "This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise. This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise.",
-									"type": "text",
-									"details": {
-										"prop_align": "J",
 										"prop_left": 3,
 										"prop_right": 3,
 										"prop_top": 3
@@ -411,6 +357,98 @@
 				},
 				{
 					"value": 16.997500000000002,
+					"type": "row",
+					"nodes": [
+						{
+							"value": 12,
+							"type": "col"
+						}
+					]
+				}
+			]
+		},
+		{
+			"type": "page",
+			"nodes": [
+				{
+					"value": 45,
+					"type": "row",
+					"nodes": [
+						{
+							"value": 2,
+							"type": "col",
+							"nodes": [
+								{
+									"value": "This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise.",
+									"type": "text",
+									"details": {
+										"prop_align": "J",
+										"prop_breakline_strategy": "dash_strategy",
+										"prop_left": 3,
+										"prop_right": 3,
+										"prop_top": 3
+									}
+								}
+							]
+						},
+						{
+							"value": 4,
+							"type": "col",
+							"nodes": [
+								{
+									"value": "This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise. This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise.",
+									"type": "text",
+									"details": {
+										"prop_align": "J",
+										"prop_left": 3,
+										"prop_right": 3,
+										"prop_top": 10
+									}
+								}
+							]
+						},
+						{
+							"value": 6,
+							"type": "col",
+							"nodes": [
+								{
+									"value": "This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise. This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise.",
+									"type": "text",
+									"details": {
+										"prop_align": "J",
+										"prop_hyperlink": "https://google.com",
+										"prop_left": 10,
+										"prop_right": 10,
+										"prop_top": 10
+									}
+								}
+							]
+						}
+					]
+				},
+				{
+					"value": 10,
+					"type": "row",
+					"nodes": [
+						{
+							"value": 0,
+							"type": "col",
+							"details": {
+								"is_max": true
+							},
+							"nodes": [
+								{
+									"value": "Justify-aligned text" ,
+									"type": "text",
+									"details": {
+										"prop_align": "J"
+									}								}
+							]
+						}
+					]
+				},
+				{
+					"value": 211.9975,
 					"type": "row",
 					"nodes": [
 						{


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->

Added the justified alignment type for texts, which aligns the text with the margins.
The new type calculates the size of white space needed to completely fill a line.

![image](https://github.com/johnfercher/maroto/assets/84243254/0eba5847-7b3b-4a17-bc7c-b51b5a0cdcb6)

**Related Issue**
<!-- If it has any issue related to this PR, please add a reference here. -->

**Checklist**
> check with "x", **ONLY IF APPLIED** to your change

- [X] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [X] Wrote unit tests for new/changed features. <!-- If applied -->
- [ ] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [ ] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/doc.go and docs/* <!-- If applied -->
- [X] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [ ] Executed `make dod` with none issues pointed out by `golangci-lint`