### PR TITLE
feature/barcodes-in-png

### DIFF
--- a/internal/code/code.go
+++ b/internal/code/code.go
@@ -3,7 +3,9 @@ package code
 import (
 	"bytes"
 	"image"
-	"image/jpeg"
+	"image/color/palette"
+	"image/draw"
+	"image/png"
 
 	"github.com/boombuler/barcode/code128"
 	"github.com/boombuler/barcode/ean"
@@ -85,17 +87,22 @@ func getBarcodeClosure(barcodeType barcode.Type) func(code string) (libBarcode.B
 
 func (c *code) getImage(img image.Image) (*entity.Image, error) {
 	var buf bytes.Buffer
-	err := jpeg.Encode(&buf, img, nil)
+
+	dst := image.NewPaletted(img.Bounds(), palette.Plan9)
+	drawer := draw.Drawer(draw.Src)
+	drawer.Draw(dst, dst.Bounds(), img, img.Bounds().Min)
+
+	err := png.Encode(&buf, dst)
 	if err != nil {
 		return nil, err
 	}
 
 	imgEntity := &entity.Image{
 		Bytes:     buf.Bytes(),
-		Extension: extension.Jpg,
+		Extension: extension.Png,
 		Dimensions: &entity.Dimensions{
-			Width:  float64(img.Bounds().Dx()),
-			Height: float64(img.Bounds().Dy()),
+			Width:  float64(dst.Bounds().Dx()),
+			Height: float64(dst.Bounds().Dy()),
 		},
 	}
 

--- a/internal/providers/gofpdf/provider.go
+++ b/internal/providers/gofpdf/provider.go
@@ -57,7 +57,7 @@ func (g *provider) AddLine(cell *entity.Cell, prop *props.Line) {
 }
 
 func (g *provider) AddMatrixCode(code string, cell *entity.Cell, prop *props.Rect) {
-	image, err := g.cache.GetImage(code, extension.Jpg)
+	image, err := g.cache.GetImage(code, extension.Png)
 	if err != nil {
 		image, err = g.code.GenDataMatrix(code)
 	}
@@ -67,7 +67,7 @@ func (g *provider) AddMatrixCode(code string, cell *entity.Cell, prop *props.Rec
 	}
 
 	g.cache.AddImage(code, image)
-	err = g.image.Add(image, cell, g.cfg.Margins, prop, extension.Jpg, false)
+	err = g.image.Add(image, cell, g.cfg.Margins, prop, extension.Png, false)
 	if err != nil {
 		g.fpdf.ClearError()
 		g.text.Add("could not add matrixcode to document", cell, merror.DefaultErrorText)
@@ -75,7 +75,7 @@ func (g *provider) AddMatrixCode(code string, cell *entity.Cell, prop *props.Rec
 }
 
 func (g *provider) AddQrCode(code string, cell *entity.Cell, prop *props.Rect) {
-	image, err := g.cache.GetImage(code, extension.Jpg)
+	image, err := g.cache.GetImage(code, extension.Png)
 	if err != nil {
 		image, err = g.code.GenQr(code)
 	}
@@ -85,7 +85,7 @@ func (g *provider) AddQrCode(code string, cell *entity.Cell, prop *props.Rect) {
 	}
 
 	g.cache.AddImage(code, image)
-	err = g.image.Add(image, cell, g.cfg.Margins, prop, extension.Jpg, false)
+	err = g.image.Add(image, cell, g.cfg.Margins, prop, extension.Png, false)
 	if err != nil {
 		g.fpdf.ClearError()
 		g.text.Add("could not add qrcode to document", cell, merror.DefaultErrorText)
@@ -93,7 +93,7 @@ func (g *provider) AddQrCode(code string, cell *entity.Cell, prop *props.Rect) {
 }
 
 func (g *provider) AddBarCode(code string, cell *entity.Cell, prop *props.Barcode) {
-	image, err := g.cache.GetImage(g.getBarcodeImageName(code, prop), extension.Jpg)
+	image, err := g.cache.GetImage(g.getBarcodeImageName(code, prop), extension.Png)
 	if err != nil {
 		image, err = g.code.GenBar(code, cell, prop)
 	}
@@ -103,7 +103,7 @@ func (g *provider) AddBarCode(code string, cell *entity.Cell, prop *props.Barcod
 	}
 
 	g.cache.AddImage(g.getBarcodeImageName(code, prop), image)
-	err = g.image.Add(image, cell, g.cfg.Margins, prop.ToRectProp(), extension.Jpg, false)
+	err = g.image.Add(image, cell, g.cfg.Margins, prop.ToRectProp(), extension.Png, false)
 	if err != nil {
 		g.fpdf.ClearError()
 		g.text.Add("could not add barcode to document", cell, merror.DefaultErrorText)

--- a/internal/providers/gofpdf/provider_test.go
+++ b/internal/providers/gofpdf/provider_test.go
@@ -104,7 +104,7 @@ func TestProvider_AddMatrixCode(t *testing.T) {
 		prop := fixture.RectProp()
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent, extension.Jpg).Return(nil, errors.New("anyError1"))
+		cache.EXPECT().GetImage(codeContent, extension.Png).Return(nil, errors.New("anyError1"))
 
 		code := mocks.NewCode(t)
 		code.EXPECT().GenDataMatrix(codeContent).Return(nil, errors.New("anyError2"))
@@ -136,7 +136,7 @@ func TestProvider_AddMatrixCode(t *testing.T) {
 		img := &entity.Image{Bytes: []byte{1, 2, 3}}
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent, extension.Jpg).Return(img, nil)
+		cache.EXPECT().GetImage(codeContent, extension.Png).Return(img, nil)
 		cache.EXPECT().AddImage(codeContent, img)
 
 		text := mocks.NewText(t)
@@ -152,7 +152,7 @@ func TestProvider_AddMatrixCode(t *testing.T) {
 		}
 
 		image := mocks.NewImage(t)
-		image.EXPECT().Add(img, cell, cfg.Margins, &prop, extension.Jpg, false).Return(errors.New("anyError"))
+		image.EXPECT().Add(img, cell, cfg.Margins, &prop, extension.Png, false).Return(errors.New("anyError"))
 
 		fpdf := mocks.NewFpdf(t)
 		fpdf.EXPECT().ClearError()
@@ -184,7 +184,7 @@ func TestProvider_AddMatrixCode(t *testing.T) {
 		img := &entity.Image{Bytes: []byte{1, 2, 3}}
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent, extension.Jpg).Return(img, nil)
+		cache.EXPECT().GetImage(codeContent, extension.Png).Return(img, nil)
 		cache.EXPECT().AddImage(codeContent, img)
 
 		cfg := &entity.Config{
@@ -197,7 +197,7 @@ func TestProvider_AddMatrixCode(t *testing.T) {
 		}
 
 		image := mocks.NewImage(t)
-		image.EXPECT().Add(img, cell, cfg.Margins, &prop, extension.Jpg, false).Return(nil)
+		image.EXPECT().Add(img, cell, cfg.Margins, &prop, extension.Png, false).Return(nil)
 
 		dep := &gofpdf.Dependencies{
 			Cache: cache,
@@ -225,7 +225,7 @@ func TestProvider_AddQrCode(t *testing.T) {
 		prop := fixture.RectProp()
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent, extension.Jpg).Return(nil, errors.New("anyError1"))
+		cache.EXPECT().GetImage(codeContent, extension.Png).Return(nil, errors.New("anyError1"))
 
 		code := mocks.NewCode(t)
 		code.EXPECT().GenQr(codeContent).Return(nil, errors.New("anyError2"))
@@ -257,7 +257,7 @@ func TestProvider_AddQrCode(t *testing.T) {
 		img := &entity.Image{Bytes: []byte{1, 2, 3}}
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent, extension.Jpg).Return(img, nil)
+		cache.EXPECT().GetImage(codeContent, extension.Png).Return(img, nil)
 		cache.EXPECT().AddImage(codeContent, img)
 
 		text := mocks.NewText(t)
@@ -273,7 +273,7 @@ func TestProvider_AddQrCode(t *testing.T) {
 		}
 
 		image := mocks.NewImage(t)
-		image.EXPECT().Add(img, cell, cfg.Margins, &prop, extension.Jpg, false).Return(errors.New("anyError"))
+		image.EXPECT().Add(img, cell, cfg.Margins, &prop, extension.Png, false).Return(errors.New("anyError"))
 
 		fpdf := mocks.NewFpdf(t)
 		fpdf.EXPECT().ClearError()
@@ -305,7 +305,7 @@ func TestProvider_AddQrCode(t *testing.T) {
 		img := &entity.Image{Bytes: []byte{1, 2, 3}}
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent, extension.Jpg).Return(img, nil)
+		cache.EXPECT().GetImage(codeContent, extension.Png).Return(img, nil)
 		cache.EXPECT().AddImage(codeContent, img)
 
 		cfg := &entity.Config{
@@ -318,7 +318,7 @@ func TestProvider_AddQrCode(t *testing.T) {
 		}
 
 		image := mocks.NewImage(t)
-		image.EXPECT().Add(img, cell, cfg.Margins, &prop, extension.Jpg, false).Return(nil)
+		image.EXPECT().Add(img, cell, cfg.Margins, &prop, extension.Png, false).Return(nil)
 
 		dep := &gofpdf.Dependencies{
 			Cache: cache,
@@ -346,7 +346,7 @@ func TestProvider_AddBarCode(t *testing.T) {
 		prop := fixture.BarcodeProp()
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent+"code128", extension.Jpg).Return(nil, errors.New("anyError1"))
+		cache.EXPECT().GetImage(codeContent+"code128", extension.Png).Return(nil, errors.New("anyError1"))
 
 		code := mocks.NewCode(t)
 		code.EXPECT().GenBar(codeContent, cell, &prop).Return(nil, errors.New("anyError2"))
@@ -378,7 +378,7 @@ func TestProvider_AddBarCode(t *testing.T) {
 		img := &entity.Image{Bytes: []byte{1, 2, 3}}
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent+"code128", extension.Jpg).Return(img, nil)
+		cache.EXPECT().GetImage(codeContent+"code128", extension.Png).Return(img, nil)
 		cache.EXPECT().AddImage(codeContent+"code128", img)
 
 		text := mocks.NewText(t)
@@ -394,7 +394,7 @@ func TestProvider_AddBarCode(t *testing.T) {
 		}
 
 		image := mocks.NewImage(t)
-		image.EXPECT().Add(img, cell, cfg.Margins, prop.ToRectProp(), extension.Jpg, false).Return(errors.New("anyError"))
+		image.EXPECT().Add(img, cell, cfg.Margins, prop.ToRectProp(), extension.Png, false).Return(errors.New("anyError"))
 
 		fpdf := mocks.NewFpdf(t)
 		fpdf.EXPECT().ClearError()
@@ -426,7 +426,7 @@ func TestProvider_AddBarCode(t *testing.T) {
 		img := &entity.Image{Bytes: []byte{1, 2, 3}}
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent+"code128", extension.Jpg).Return(img, nil)
+		cache.EXPECT().GetImage(codeContent+"code128", extension.Png).Return(img, nil)
 		cache.EXPECT().AddImage(codeContent+"code128", img)
 
 		cfg := &entity.Config{
@@ -439,7 +439,7 @@ func TestProvider_AddBarCode(t *testing.T) {
 		}
 
 		image := mocks.NewImage(t)
-		image.EXPECT().Add(img, cell, cfg.Margins, prop.ToRectProp(), extension.Jpg, false).Return(nil)
+		image.EXPECT().Add(img, cell, cfg.Margins, prop.ToRectProp(), extension.Png, false).Return(nil)
 
 		dep := &gofpdf.Dependencies{
 			Cache: cache,
@@ -466,7 +466,7 @@ func TestProvider_AddBarCode(t *testing.T) {
 		img := &entity.Image{Bytes: []byte{1, 2, 3}}
 
 		cache := mocks.NewCache(t)
-		cache.EXPECT().GetImage(codeContent+"ean", extension.Jpg).Return(img, nil)
+		cache.EXPECT().GetImage(codeContent+"ean", extension.Png).Return(img, nil)
 		cache.EXPECT().AddImage(codeContent+"ean", img)
 
 		cfg := &entity.Config{
@@ -479,7 +479,7 @@ func TestProvider_AddBarCode(t *testing.T) {
 		}
 
 		image := mocks.NewImage(t)
-		image.EXPECT().Add(img, cell, cfg.Margins, prop.ToRectProp(), extension.Jpg, false).Return(nil)
+		image.EXPECT().Add(img, cell, cfg.Margins, prop.ToRectProp(), extension.Png, false).Return(nil)
 
 		dep := &gofpdf.Dependencies{
 			Cache: cache,


### PR DESCRIPTION
`PNG` format fits better for barcodes because it uses lossless compression (in contrast to `JPEG`).

#413 