### PR TITLE
Fix/vertical padding

### DIFF
--- a/docs/assets/examples/textgrid/v2/main.go
+++ b/docs/assets/examples/textgrid/v2/main.go
@@ -104,5 +104,9 @@ func GetMaroto() core.Maroto {
 	m.AddAutoRow(
 		text.NewCol(12, longText+" "+longText+" "+longText, props.Text{Left: 3, Right: 3, Align: align.Justify, BreakLineStrategy: breakline.EmptySpaceStrategy}),
 	)
+
+	m.AddAutoRow(
+		text.NewCol(12, longText+" "+longText+" "+longText, props.Text{VerticalPadding: 10, Left: 3, Right: 3, Align: align.Justify, BreakLineStrategy: breakline.EmptySpaceStrategy}),
+	)
 	return m
 }

--- a/docs/assets/pdf/textgridv2.pdf
+++ b/docs/assets/pdf/textgridv2.pdf
@@ -7,13 +7,15 @@
 /Contents 4 0 R>>
 endobj
 4 0 obj
-<</Length 8148>>
+<</Length 8264>>
 stream
 0 J
 0 j
 0.57 w
 0.000 G
 0.000 g
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
 BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
@@ -177,7 +179,7 @@ endobj
 /Contents 6 0 R>>
 endobj
 6 0 obj
-<</Length 17143>>
+<</Length 19558>>
 stream
 0 J
 0 j
@@ -571,7 +573,76 @@ BT 418.57 537.64 Td (into) Tj ET
 BT 445.37 537.64 Td (the) Tj ET
 BT 469.95 537.64 Td (column) Tj ET
 BT 512.86 537.64 Td (otherwise.) Tj ET
-28.35 537.64 538.58 -480.94 re S 
+28.35 537.64 538.58 -86.69 re S 
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 527.64 Td (This) Tj ET
+BT 59.21 527.64 Td (is) Tj ET
+BT 69.89 527.64 Td (a) Tj ET
+BT 78.92 527.64 Td (longer) Tj ET
+BT 110.18 527.64 Td (sentence) Tj ET
+BT 154.23 527.64 Td (that) Tj ET
+BT 174.37 527.64 Td (will) Tj ET
+BT 191.72 527.64 Td (be) Tj ET
+BT 206.31 527.64 Td (broken) Tj ET
+BT 240.34 527.64 Td (into) Tj ET
+BT 259.93 527.64 Td (multiple) Tj ET
+BT 297.85 527.64 Td (lines) Tj ET
+BT 321.88 527.64 Td (as) Tj ET
+BT 335.90 527.64 Td (it) Tj ET
+BT 344.37 527.64 Td (does) Tj ET
+BT 369.52 527.64 Td (not) Tj ET
+BT 386.89 527.64 Td (fit) Tj ET
+BT 398.13 527.64 Td (into) Tj ET
+BT 417.72 527.64 Td (the) Tj ET
+BT 435.09 527.64 Td (column) Tj ET
+BT 470.78 527.64 Td (otherwise.) Tj ET
+BT 519.82 527.64 Td (This) Tj ET
+BT 542.18 527.64 Td (is) Tj ET
+BT 552.87 527.64 Td (a) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 489.29 Td (longer) Tj ET
+BT 68.62 489.29 Td (sentence) Tj ET
+BT 113.18 489.29 Td (that) Tj ET
+BT 133.85 489.29 Td (will) Tj ET
+BT 151.71 489.29 Td (be) Tj ET
+BT 166.81 489.29 Td (broken) Tj ET
+BT 201.36 489.29 Td (into) Tj ET
+BT 221.47 489.29 Td (multiple) Tj ET
+BT 259.90 489.29 Td (lines) Tj ET
+BT 284.44 489.29 Td (as) Tj ET
+BT 298.98 489.29 Td (it) Tj ET
+BT 307.96 489.29 Td (does) Tj ET
+BT 333.63 489.29 Td (not) Tj ET
+BT 351.51 489.29 Td (fit) Tj ET
+BT 363.27 489.29 Td (into) Tj ET
+BT 383.37 489.29 Td (the) Tj ET
+BT 401.25 489.29 Td (column) Tj ET
+BT 437.47 489.29 Td (otherwise.) Tj ET
+BT 487.02 489.29 Td (This) Tj ET
+BT 509.89 489.29 Td (is) Tj ET
+BT 521.09 489.29 Td (a) Tj ET
+BT 530.64 489.29 Td (longer) Tj ET
+BT /F0a76705d18e0494dd24cb573e53aa0a8c710ec99 10.00 Tf ET
+BT 36.85 450.94 Td (sentence) Tj ET
+BT 88.11 450.94 Td (that) Tj ET
+BT 115.47 450.94 Td (will) Tj ET
+BT 140.03 450.94 Td (be) Tj ET
+BT 161.83 450.94 Td (broken) Tj ET
+BT 203.08 450.94 Td (into) Tj ET
+BT 229.88 450.94 Td (multiple) Tj ET
+BT 275.01 450.94 Td (lines) Tj ET
+BT 306.25 450.94 Td (as) Tj ET
+BT 327.49 450.94 Td (it) Tj ET
+BT 343.17 450.94 Td (does) Tj ET
+BT 375.53 450.94 Td (not) Tj ET
+BT 400.11 450.94 Td (fit) Tj ET
+BT 418.57 450.94 Td (into) Tj ET
+BT 445.37 450.94 Td (the) Tj ET
+BT 469.95 450.94 Td (column) Tj ET
+BT 512.86 450.94 Td (otherwise.) Tj ET
+28.35 450.94 538.58 -394.24 re S 
 
 endstream
 endobj
@@ -604,8 +675,8 @@ endobj
 8 0 obj
 <<
 /Producer (þÿ F P D F   1 . 7)
-/CreationDate (D:20240801203854)
-/ModDate (D:20240801203854)
+/CreationDate (D:20240821172849)
+/ModDate (D:20240821172849)
 >>
 endobj
 9 0 obj
@@ -622,15 +693,15 @@ endobj
 xref
 0 10
 0000000000 65535 f 
-0000027314 00000 n 
-0000027503 00000 n 
+0000029845 00000 n 
+0000030034 00000 n 
 0000000009 00000 n 
 0000000221 00000 n 
-0000008419 00000 n 
-0000010120 00000 n 
-0000027407 00000 n 
-0000027664 00000 n 
-0000027777 00000 n 
+0000008535 00000 n 
+0000010236 00000 n 
+0000029938 00000 n 
+0000030195 00000 n 
+0000030308 00000 n 
 trailer
 <<
 /Size 10
@@ -638,5 +709,5 @@ trailer
 /Info 8 0 R
 >>
 startxref
-27874
+30405
 %%EOF

--- a/docs/assets/text/textgridv2.txt
+++ b/docs/assets/text/textgridv2.txt
@@ -1,4 +1,4 @@
-generate -> avg: 4.97ms, executions: [4.97ms]
-add_row -> avg: 325.33ns, executions: [946.00ns, 211.00ns, 103.00ns, 91.00ns, 92.00ns, 509.00ns]
-add_rows -> avg: 76.50ns, executions: [127.00ns, 85.00ns, 41.00ns, 87.00ns, 36.00ns, 83.00ns]
-file_size -> 28.15Kb
+generate -> avg: 36.66ms, executions: [36.66ms]
+add_row -> avg: 1401.00ns, executions: [3.05μs, 0.88μs, 0.61μs, 0.58μs, 0.66μs, 2.62μs]
+add_rows -> avg: 368.83ns, executions: [511.00ns, 430.00ns, 190.00ns, 441.00ns, 130.00ns, 511.00ns]
+file_size -> 30.68Kb

--- a/internal/providers/gofpdf/provider.go
+++ b/internal/providers/gofpdf/provider.go
@@ -54,7 +54,7 @@ func (g *provider) GetLinesQuantity(text string, textProp *props.Text, colWidth 
 	return g.text.GetLinesQuantity(text, textProp, colWidth)
 }
 
-func (g *provider) GetTextHeight(prop *props.Font) float64 {
+func (g *provider) GetFontHeight(prop *props.Font) float64 {
 	return g.font.GetHeight(prop.Family, prop.Style, prop.Size)
 }
 

--- a/internal/providers/gofpdf/provider_test.go
+++ b/internal/providers/gofpdf/provider_test.go
@@ -71,7 +71,7 @@ func TestProvider_GetTextHeight(t *testing.T) {
 	sut := gofpdf.New(dep)
 
 	// Act
-	fontHeight := sut.GetTextHeight(&prop)
+	fontHeight := sut.GetFontHeight(&prop)
 
 	// Assert
 	font.AssertNumberOfCalls(t, "GetHeight", 1)

--- a/mocks/Provider.go
+++ b/mocks/Provider.go
@@ -664,6 +664,52 @@ func (_c *Provider_GetDimensionsByQrCode_Call) RunAndReturn(run func(string) (*e
 	return _c
 }
 
+// GetFontHeight provides a mock function with given fields: prop
+func (_m *Provider) GetFontHeight(prop *props.Font) float64 {
+	ret := _m.Called(prop)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFontHeight")
+	}
+
+	var r0 float64
+	if rf, ok := ret.Get(0).(func(*props.Font) float64); ok {
+		r0 = rf(prop)
+	} else {
+		r0 = ret.Get(0).(float64)
+	}
+
+	return r0
+}
+
+// Provider_GetFontHeight_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFontHeight'
+type Provider_GetFontHeight_Call struct {
+	*mock.Call
+}
+
+// GetFontHeight is a helper method to define mock.On call
+//   - prop *props.Font
+func (_e *Provider_Expecter) GetFontHeight(prop interface{}) *Provider_GetFontHeight_Call {
+	return &Provider_GetFontHeight_Call{Call: _e.mock.On("GetFontHeight", prop)}
+}
+
+func (_c *Provider_GetFontHeight_Call) Run(run func(prop *props.Font)) *Provider_GetFontHeight_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*props.Font))
+	})
+	return _c
+}
+
+func (_c *Provider_GetFontHeight_Call) Return(_a0 float64) *Provider_GetFontHeight_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Provider_GetFontHeight_Call) RunAndReturn(run func(*props.Font) float64) *Provider_GetFontHeight_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetLinesQuantity provides a mock function with given fields: text, textProp, colWidth
 func (_m *Provider) GetLinesQuantity(text string, textProp *props.Text, colWidth float64) int {
 	ret := _m.Called(text, textProp, colWidth)
@@ -708,52 +754,6 @@ func (_c *Provider_GetLinesQuantity_Call) Return(_a0 int) *Provider_GetLinesQuan
 }
 
 func (_c *Provider_GetLinesQuantity_Call) RunAndReturn(run func(string, *props.Text, float64) int) *Provider_GetLinesQuantity_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetTextHeight provides a mock function with given fields: prop
-func (_m *Provider) GetTextHeight(prop *props.Font) float64 {
-	ret := _m.Called(prop)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTextHeight")
-	}
-
-	var r0 float64
-	if rf, ok := ret.Get(0).(func(*props.Font) float64); ok {
-		r0 = rf(prop)
-	} else {
-		r0 = ret.Get(0).(float64)
-	}
-
-	return r0
-}
-
-// Provider_GetTextHeight_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTextHeight'
-type Provider_GetTextHeight_Call struct {
-	*mock.Call
-}
-
-// GetTextHeight is a helper method to define mock.On call
-//   - prop *props.Font
-func (_e *Provider_Expecter) GetTextHeight(prop interface{}) *Provider_GetTextHeight_Call {
-	return &Provider_GetTextHeight_Call{Call: _e.mock.On("GetTextHeight", prop)}
-}
-
-func (_c *Provider_GetTextHeight_Call) Run(run func(prop *props.Font)) *Provider_GetTextHeight_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*props.Font))
-	})
-	return _c
-}
-
-func (_c *Provider_GetTextHeight_Call) Return(_a0 float64) *Provider_GetTextHeight_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Provider_GetTextHeight_Call) RunAndReturn(run func(*props.Font) float64) *Provider_GetTextHeight_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/components/signature/signature.go
+++ b/pkg/components/signature/signature.go
@@ -55,7 +55,7 @@ func NewAutoRow(value string, ps ...props.Signature) core.Row {
 
 // Render renders a Signature into a PDF context.
 func (s *Signature) Render(provider core.Provider, cell *entity.Cell) {
-	fontSize := provider.GetTextHeight(s.prop.ToFontProp()) * s.prop.SafePadding
+	fontSize := provider.GetFontHeight(s.prop.ToFontProp()) * s.prop.SafePadding
 
 	textProp := s.prop.ToTextProp(align.Center, cell.Height-fontSize, 0)
 
@@ -78,7 +78,7 @@ func (s *Signature) GetStructure() *node.Node[core.Structure] {
 
 // GetHeight returns the height that the signature will have in the PDF
 func (s *Signature) GetHeight(provider core.Provider, cell *entity.Cell) float64 {
-	return s.prop.LineThickness + provider.GetTextHeight(s.prop.ToFontProp())*s.prop.SafePadding
+	return s.prop.LineThickness + provider.GetFontHeight(s.prop.ToFontProp())*s.prop.SafePadding
 }
 
 // SetConfig sets the config.

--- a/pkg/components/signature/signature_test.go
+++ b/pkg/components/signature/signature_test.go
@@ -90,7 +90,7 @@ func TestSignature_Render(t *testing.T) {
 
 		provider := mocks.NewProvider(t)
 		provider.On("AddText", mock.Anything, mock.Anything, mock.Anything).Return(10.0)
-		provider.On("GetTextHeight", mock.Anything).Return(10.0)
+		provider.On("GetFontHeight", mock.Anything).Return(10.0)
 		provider.On("AddLine", mock.Anything, mock.Anything)
 
 		// Act
@@ -98,7 +98,7 @@ func TestSignature_Render(t *testing.T) {
 
 		// Assert
 		provider.AssertNumberOfCalls(t, "AddText", 1)
-		provider.AssertNumberOfCalls(t, "GetTextHeight", 1)
+		provider.AssertNumberOfCalls(t, "GetFontHeight", 1)
 		provider.AssertNumberOfCalls(t, "AddLine", 1)
 	})
 }
@@ -129,7 +129,7 @@ func TestSignature_GetHeight(t *testing.T) {
 			})
 
 		provider := mocks.NewProvider(t)
-		provider.EXPECT().GetTextHeight(&font).Return(5.0)
+		provider.EXPECT().GetFontHeight(&font).Return(5.0)
 
 		// Act
 		height := sut.GetHeight(provider, &cell)

--- a/pkg/components/text/text.go
+++ b/pkg/components/text/text.go
@@ -63,9 +63,10 @@ func (t *Text) GetStructure() *node.Node[core.Structure] {
 
 // GetHeight returns the height that the text will have in the PDF
 func (t *Text) GetHeight(provider core.Provider, cell *entity.Cell) float64 {
-	lines := provider.GetLinesQuantity(t.value, &t.prop, cell.Width-t.prop.Left-t.prop.Right)
-	height := provider.GetTextHeight(&props.Font{Family: t.prop.Family, Style: t.prop.Style, Size: t.prop.Size, Color: t.prop.Color})
-	return (float64(lines) * height) + t.prop.Top
+	amountLines := provider.GetLinesQuantity(t.value, &t.prop, cell.Width-t.prop.Left-t.prop.Right)
+	fontHeight := provider.GetFontHeight(&props.Font{Family: t.prop.Family, Style: t.prop.Style, Size: t.prop.Size, Color: t.prop.Color})
+	textHeight := float64(amountLines)*fontHeight + float64(amountLines-1)*t.prop.VerticalPadding
+	return textHeight + t.prop.Top
 }
 
 // SetConfig sets the config.

--- a/pkg/components/text/text_test.go
+++ b/pkg/components/text/text_test.go
@@ -132,7 +132,7 @@ func TestText_GetHeight(t *testing.T) {
 		assert.Equal(t, 20.0, height)
 	})
 
-	t.Run("When verical padding is sent, should increment row height with vertical padding", func(t *testing.T) {
+	t.Run("When vertical padding is sent, should increment row height with vertical padding", func(t *testing.T) {
 		cell := fixture.CellEntity()
 		font := fixture.FontProp()
 		textProp := props.Text{VerticalPadding: 5}

--- a/pkg/components/text/text_test.go
+++ b/pkg/components/text/text_test.go
@@ -115,19 +115,54 @@ func TestText_SetConfig(t *testing.T) {
 }
 
 func TestText_GetHeight(t *testing.T) {
-	t.Run("When text has a height of 22, should return 22", func(t *testing.T) {
+	t.Run("When top margin is sent, should increment row height with top margin", func(t *testing.T) {
 		cell := fixture.CellEntity()
-		textProp := fixture.TextProp()
-		font := props.Font{Family: textProp.Family, Style: textProp.Style, Size: textProp.Size, Color: textProp.Color}
+		font := fixture.FontProp()
+		textProp := props.Text{Top: 10}
+		textProp.MakeValid(&font)
 
 		sut := text.New("text", textProp)
 
 		provider := mocks.NewProvider(t)
-		provider.EXPECT().GetLinesQuantity("text", &textProp, 97.0).Return(5.0)
-		provider.EXPECT().GetTextHeight(&font).Return(2.0)
+		provider.EXPECT().GetLinesQuantity("text", &textProp, 100.0).Return(5.0)
+		provider.EXPECT().GetFontHeight(&font).Return(2.0)
 
 		// Act
 		height := sut.GetHeight(provider, &cell)
-		assert.Equal(t, 22.0, height)
+		assert.Equal(t, 20.0, height)
+	})
+
+	t.Run("When verical padding is sent, should increment row height with vertical padding", func(t *testing.T) {
+		cell := fixture.CellEntity()
+		font := fixture.FontProp()
+		textProp := props.Text{VerticalPadding: 5}
+		textProp.MakeValid(&font)
+
+		sut := text.New("text", textProp)
+
+		provider := mocks.NewProvider(t)
+		provider.EXPECT().GetLinesQuantity("text", &textProp, 100.0).Return(5.0)
+		provider.EXPECT().GetFontHeight(&font).Return(2.0)
+
+		// Act
+		height := sut.GetHeight(provider, &cell)
+		assert.Equal(t, 30.0, height)
+	})
+
+	t.Run("When font has a height of 2, should return 10", func(t *testing.T) {
+		cell := fixture.CellEntity()
+		font := fixture.FontProp()
+		textProp := props.Text{}
+		textProp.MakeValid(&font)
+
+		sut := text.New("text", textProp)
+
+		provider := mocks.NewProvider(t)
+		provider.EXPECT().GetLinesQuantity("text", &textProp, 100.0).Return(5.0)
+		provider.EXPECT().GetFontHeight(&font).Return(2.0)
+
+		// Act
+		height := sut.GetHeight(provider, &cell)
+		assert.Equal(t, 10.0, height)
 	})
 }

--- a/pkg/core/provider.go
+++ b/pkg/core/provider.go
@@ -15,7 +15,7 @@ type Provider interface {
 	// Features
 	AddLine(cell *entity.Cell, prop *props.Line)
 	AddText(text string, cell *entity.Cell, prop *props.Text)
-	GetTextHeight(prop *props.Font) float64
+	GetFontHeight(prop *props.Font) float64
 	GetLinesQuantity(text string, textProp *props.Text, colWidth float64) int
 	AddMatrixCode(code string, cell *entity.Cell, prop *props.Rect)
 	AddQrCode(code string, cell *entity.Cell, rect *props.Rect)

--- a/test/maroto/examples/textgrid.json
+++ b/test/maroto/examples/textgrid.json
@@ -648,7 +648,33 @@
 					]
 				},
 				{
-					"value": 169.6641666666667,
+					"value": 30.583333333333336,
+					"type": "row",
+					"nodes": [
+						{
+							"value": 12,
+							"type": "col",
+							"nodes": [
+								{
+									"value": "This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise. This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise. This is a longer sentence that will be broken into multiple lines as it does not fit into the column otherwise.",
+									"type": "text",
+									"details": {
+										"prop_align": "J",
+										"prop_breakline_strategy": "empty_space_strategy",
+										"prop_color": "RGB(0, 0, 0)",
+										"prop_font_family": "arial",
+										"prop_font_size": 10,
+										"prop_left": 3,
+										"prop_right": 3,
+										"prop_vertical_padding": 10
+									}
+								}
+							]
+						}
+					]
+				},
+				{
+					"value": 139.08083333333335,
 					"type": "row",
 					"nodes": [
 						{


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
Consider vertical padding of text when calculating line height


**Checklist**
> check with "x", **ONLY IF APPLIED** to your change

- [ ] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [x] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [x] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [x] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/doc.go and docs/* <!-- If applied -->
- [ ] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [ ] Executed `make dod` with none issues pointed out by `golangci-lint`