### PR TITLE
fix/metadata not set

### DIFF
--- a/maroto.go
+++ b/maroto.go
@@ -166,10 +166,6 @@ func (m *Maroto) RegisterFooter(rows ...core.Row) error {
 // Generate is responsible to compute the component tree created by
 // the usage of all other Maroto methods, and generate the PDF document.
 func (m *Maroto) Generate() (core.Document, error) {
-	m.provider.SetProtection(m.config.Protection)
-	m.provider.SetCompression(m.config.Compression)
-	m.provider.SetMetadata(m.config.Metadata)
-
 	m.fillPageToAddNew()
 	m.setConfig()
 
@@ -392,5 +388,9 @@ func getConfig(configs ...*entity.Config) *entity.Config {
 
 func getProvider(cache cache.Cache, cfg *entity.Config) core.Provider {
 	deps := gofpdf.NewBuilder().Build(cfg, cache)
-	return gofpdf.New(deps)
+	provider := gofpdf.New(deps)
+	provider.SetMetadata(cfg.Metadata)
+	provider.SetCompression(cfg.Compression)
+	provider.SetProtection(cfg.Protection)
+	return provider
 }


### PR DESCRIPTION
**Description**
fix bug in metadata configuration

**Related Issue**
#485

**Checklist**
> check with "x", **ONLY IF APPLIED** to your change

- [ ] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [ ] Wrote unit tests for new/changed features. <!-- If applied -->
- [ ] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [ ] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/doc.go and docs/* <!-- If applied -->
- [ ] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [x] Executed `make dod` with none issues pointed out by `golangci-lint`