### PR TITLE
feature/repository-loader

### DIFF
--- a/pkg/processor/core/core.go
+++ b/pkg/processor/core/core.go
@@ -6,10 +6,11 @@ type Processor interface {
 }
 
 type Repository interface {
-	RegisterTemplate(name string, template string) error
-	ReadTemplate(templateName string) (string, error)
+	RegisterTemplate(templateName string, template map[string]any) error
+	ReadTemplate(templateName string) (map[string]any, error)
 }
 
 type Deserializer interface {
 	Deserialize(document string) (map[string]interface{}, error)
 }
+

--- a/pkg/processor/core/core.go
+++ b/pkg/processor/core/core.go
@@ -14,3 +14,6 @@ type Deserializer interface {
 	Deserialize(document string) (map[string]interface{}, error)
 }
 
+type Loader interface {
+	Load(path string) ([]byte, error)
+}

--- a/pkg/processor/core/core.go
+++ b/pkg/processor/core/core.go
@@ -14,6 +14,8 @@ type Deserializer interface {
 	Deserialize(document string) (map[string]interface{}, error)
 }
 
+// Takes a path and returns its bytes
+// path may be file path or url
 type Loader interface {
 	Load(path string) ([]byte, error)
 }

--- a/pkg/processor/deserializer/json_deserializer.go
+++ b/pkg/processor/deserializer/json_deserializer.go
@@ -3,12 +3,17 @@ package deserializer
 
 import (
 	"encoding/json"
+
+	"github.com/johnfercher/maroto/v2/pkg/processor/core"
+	"github.com/johnfercher/maroto/v2/pkg/processor/loader"
 )
 
-type jsonDeserializer struct{}
+type jsonDeserializer struct {
+	loader core.Loader
+}
 
-func NewJsonDeserialize() *jsonDeserializer {
-	return &jsonDeserializer{}
+func NewJsonDeserializer() *jsonDeserializer {
+	return &jsonDeserializer{loader: loader.NewLoader()}
 }
 
 func (j *jsonDeserializer) Deserialize(documentJson string) (map[string]interface{}, error) {

--- a/pkg/processor/loader/loader.go
+++ b/pkg/processor/loader/loader.go
@@ -1,5 +1,3 @@
-// loader is responsible for loading assets (images, fonts)
-// into memory for templates and documents
 package loader
 
 import (
@@ -19,7 +17,9 @@ func NewLoader() *loader {
 	return &loader{}
 }
 
-func (localloader *loader) Load(path string) ([]byte, error) {
+// Load takes the path/url/uri of an asset (image, font)
+// and returns its contents.
+func (l *loader) Load(path string) ([]byte, error) {
 	ext := getExt(path)
 	if _, ok := validExts[ext]; !ok {
 		return nil, errors.Wrap(ErrUnsupportedExtension, ext)

--- a/pkg/processor/loader/loader.go
+++ b/pkg/processor/loader/loader.go
@@ -1,0 +1,105 @@
+// loader is responsible for loading assets (images, fonts)
+// into memory for templates and documents
+package loader
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type loader struct{}
+
+func NewLoader() *loader {
+	return &loader{}
+}
+
+func (localloader *loader) Load(path string) ([]byte, error) {
+	ext := getExt(path)
+	if _, ok := validExts[ext]; !ok {
+		return nil, errors.Wrap(ErrUnsupportedExtension, ext)
+	}
+
+	uri, err := url.Parse(path)
+	if err != nil {
+		return nil, errors.Wrap(ErrInvalidPath, path)
+	}
+
+	loadFn, ok := loadFuncs[uri.Scheme]
+	if !ok {
+		return nil, errors.Wrap(ErrUnsupportedProtocol, uri.Scheme)
+	}
+
+	r, err := loadFn(uri.String())
+	if err != nil {
+		return nil, errors.Wrap(ErrAccessFail, err.Error())
+	}
+	defer r.Close()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrap(ErrReadFail, err.Error())
+	}
+
+	return data, nil
+}
+
+func getExt(path string) string {
+	toks := strings.Split(path, ".")
+	if len(toks) < 2 {
+		return ""
+	}
+	return toks[len(toks)-1]
+}
+
+var validExts = map[string]struct{}{
+	"png":  {},
+	"jpg":  {},
+	"svg":  {},
+	"jpeg": {},
+	"ttf":  {},
+}
+
+var loadFuncs = map[string]func(string) (io.ReadCloser, error){
+	"http":  loadHttp,
+	"https": loadHttp,
+	"file":  loadLocal,
+	"":      loadLocal,
+}
+
+func loadLocal(path string) (io.ReadCloser, error) {
+	if strings.HasPrefix(path, "file://") {
+		path = path[len("file://"):]
+	}
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(absolutePath)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func loadHttp(path string) (io.ReadCloser, error) {
+	resp, err := http.Get(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+var (
+	ErrUnsupportedProtocol  = errors.New("unsupported protocol")
+	ErrUnsupportedExtension = errors.New("unsupported extension")
+	ErrInvalidPath          = errors.New("invalid path")
+	ErrAccessFail           = errors.New("failed to access asset")
+	ErrReadFail             = errors.New("failed to read asset")
+)

--- a/pkg/processor/loader/loader_test.go
+++ b/pkg/processor/loader/loader_test.go
@@ -1,0 +1,43 @@
+package loader_test
+
+import (
+	"testing"
+
+	"github.com/johnfercher/maroto/v2/pkg/processor/loader"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoad(t *testing.T) {
+	t.Run("when invalid extension sent, should return ErrUnsupportedExtension", func(t *testing.T) {
+		_, err := loader.NewLoader().Load("README.md")
+		assert.ErrorIs(t, err, loader.ErrUnsupportedExtension)
+	})
+
+	t.Run("when invalid path sent, should return ErrInvalidPath", func(t *testing.T) {
+		_, err := loader.NewLoader().Load("http://hi this is an invalid path.png")
+		assert.ErrorIs(t, err, loader.ErrInvalidPath)
+	})
+
+	t.Run("when path with unsupported protocol sent, should return ErrSupportedProtocol", func(t *testing.T) {
+		_, err := loader.NewLoader().Load("irc://foobar.com/asset.png")
+		assert.ErrorIs(t, err, loader.ErrUnsupportedProtocol)
+	})
+
+	t.Run("when valid local path sent, should return bytes of file", func(t *testing.T) {
+		p, err := loader.NewLoader().Load("../../../docs/assets/images/logo.png")
+		assert.NoError(t, err)
+		assert.NotNil(t, p)
+	})
+
+	t.Run("when valid file uri sent, should return bytes of file", func(t *testing.T) {
+		p, err := loader.NewLoader().Load("file://../../../docs/assets/images/logo.png")
+		assert.NoError(t, err)
+		assert.NotNil(t, p)
+	})
+
+	t.Run("when valid network path sent, should return bytes of asset", func(t *testing.T) {
+		p, err := loader.NewLoader().Load("https://www.iana.org/_img/2013.1/rir-map.svg")
+		assert.NoError(t, err)
+		assert.NotNil(t, p)
+	})
+}

--- a/pkg/processor/mappers/documentmapper/document.go
+++ b/pkg/processor/mappers/documentmapper/document.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/johnfercher/maroto/v2/pkg/processor/components/pdf"
-	"github.com/johnfercher/maroto/v2/pkg/processor/core"
 	"github.com/johnfercher/maroto/v2/pkg/processor/mappers"
 	"github.com/johnfercher/maroto/v2/pkg/processor/mappers/buildermapper"
 )
@@ -20,14 +19,10 @@ type Document struct {
 }
 
 // NewPdf is responsible for creating the pdf template
-func NewPdf(document string, deserializer core.Deserializer, factory mappers.AbstractFactoryMaps) (*Document, error) {
+func NewPdf(template map[string]any, factory mappers.AbstractFactoryMaps) (*Document, error) {
 	newPdf := Document{factory: factory}
-	template, err := deserializer.Deserialize(document)
-	if err != nil {
-		return nil, err
-	}
 
-	err = newPdf.addComponentsToPdf(template)
+	err := newPdf.addComponentsToPdf(template)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/processor/mappers/documentmapper/document_test.go
+++ b/pkg/processor/mappers/documentmapper/document_test.go
@@ -13,16 +13,6 @@ import (
 )
 
 func TestNewPdf(t *testing.T) {
-	t.Run("When an invalid field is submitted, should return an error", func(t *testing.T) {
-		invalidDocument := `{"invalid": 123}`
-		factory := mocks.NewAbstractFactoryMaps(t)
-
-		doc, err := NewPdf(invalidDocument, deserializer.NewJsonDeserialize(), factory)
-
-		assert.Nil(t, doc)
-		assert.NotNil(t, err)
-	})
-
 	t.Run("when builder is sent, should set builder", func(t *testing.T) {
 		builderDocument := `
 			{
@@ -31,8 +21,10 @@ func TestNewPdf(t *testing.T) {
 		`
 		factory := mocks.NewAbstractFactoryMaps(t)
 
-		doc, err := NewPdf(builderDocument, deserializer.NewJsonDeserialize(), factory)
+		template, err := deserializer.NewJsonDeserializer().Deserialize(builderDocument)
+		assert.Nil(t, err)
 
+		doc, err := NewPdf(template, factory)
 		assert.Nil(t, err)
 		assert.Equal(t, doc.Builder.ChunkWorkers, 10)
 	})
@@ -41,7 +33,10 @@ func TestNewPdf(t *testing.T) {
 		builderDocument := `{"builder": 10}`
 		factory := mocks.NewAbstractFactoryMaps(t)
 
-		doc, err := NewPdf(builderDocument, deserializer.NewJsonDeserialize(), factory)
+		template, err := deserializer.NewJsonDeserializer().Deserialize(builderDocument)
+		assert.Nil(t, err)
+
+		doc, err := NewPdf(template, factory)
 
 		assert.NotNil(t, err)
 		assert.Nil(t, doc)
@@ -58,7 +53,10 @@ func TestNewPdf(t *testing.T) {
 		factory := mocks.NewAbstractFactoryMaps(t)
 		factory.On("NewRow", mock.Anything, mock.Anything).Return(validRow, nil)
 
-		doc, err := NewPdf(builderDocument, deserializer.NewJsonDeserialize(), factory)
+		template, err := deserializer.NewJsonDeserializer().Deserialize(builderDocument)
+		assert.Nil(t, err)
+
+		doc, err := NewPdf(template, factory)
 
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(doc.Header))
@@ -68,8 +66,10 @@ func TestNewPdf(t *testing.T) {
 		builderDocument := `{"header": 1}`
 		factory := mocks.NewAbstractFactoryMaps(t)
 
-		_, err := NewPdf(builderDocument, deserializer.NewJsonDeserialize(), factory)
+		template, err := deserializer.NewJsonDeserializer().Deserialize(builderDocument)
+		assert.Nil(t, err)
 
+		_, err = NewPdf(template, factory)
 		assert.NotNil(t, err)
 	})
 
@@ -84,7 +84,10 @@ func TestNewPdf(t *testing.T) {
 		factory := mocks.NewAbstractFactoryMaps(t)
 		factory.On("NewRow", mock.Anything, mock.Anything).Return(validRow, nil)
 
-		doc, err := NewPdf(builderDocument, deserializer.NewJsonDeserialize(), factory)
+		template, err := deserializer.NewJsonDeserializer().Deserialize(builderDocument)
+		assert.Nil(t, err)
+
+		doc, err := NewPdf(template, factory)
 
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(doc.Footer))
@@ -94,7 +97,10 @@ func TestNewPdf(t *testing.T) {
 		builderDocument := `{"footer": 1}`
 		factory := mocks.NewAbstractFactoryMaps(t)
 
-		_, err := NewPdf(builderDocument, deserializer.NewJsonDeserialize(), factory)
+		template, err := deserializer.NewJsonDeserializer().Deserialize(builderDocument)
+		assert.Nil(t, err)
+
+		_, err = NewPdf(template, factory)
 
 		assert.NotNil(t, err)
 	})
@@ -111,7 +117,10 @@ func TestNewPdf(t *testing.T) {
 		factory.On("NewPage", mock.Anything, "page_template_1").Return(validPage, nil)
 		factory.On("NewPage", mock.Anything, "page_template_2").Return(validPage, nil)
 
-		doc, err := NewPdf(builderDocument, deserializer.NewJsonDeserialize(), factory)
+		template, err := deserializer.NewJsonDeserializer().Deserialize(builderDocument)
+		assert.Nil(t, err)
+
+		doc, err := NewPdf(template, factory)
 
 		assert.Nil(t, err)
 		assert.Equal(t, len(doc.pages), 2)
@@ -128,7 +137,10 @@ func TestNewPdf(t *testing.T) {
 		factory := mocks.NewAbstractFactoryMaps(t)
 		factory.On("NewList", mock.Anything, "list_template_1", mock.Anything).Return(validPage, nil)
 
-		doc, err := NewPdf(builderDocument, deserializer.NewJsonDeserialize(), factory)
+		template, err := deserializer.NewJsonDeserializer().Deserialize(builderDocument)
+		assert.Nil(t, err)
+
+		doc, err := NewPdf(template, factory)
 
 		assert.Nil(t, err)
 		assert.Equal(t, len(doc.pages), 1)
@@ -139,8 +151,10 @@ func TestNewPdf(t *testing.T) {
 		builderDocument := `{"pages": 1}`
 		factory := mocks.NewAbstractFactoryMaps(t)
 
-		_, err := NewPdf(builderDocument, deserializer.NewJsonDeserialize(), factory)
+		template, err := deserializer.NewJsonDeserializer().Deserialize(builderDocument)
+		assert.Nil(t, err)
 
+		_, err = NewPdf(template, factory)
 		assert.NotNil(t, err)
 	})
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -19,7 +19,7 @@ type processor struct {
 func NewProcessor() *processor {
 	return &processor{
 		repository:   repository.NewMemoryStorage(),
-		deserializer: deserializer.NewJsonDeserialize(),
+		deserializer: deserializer.NewJsonDeserializer(),
 	}
 }
 

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -13,23 +13,31 @@ import (
 type processor struct {
 	repository   core.Repository
 	deserializer core.Deserializer
+	loader       core.Loader
 }
 
 func NewProcessor() *processor {
-	return &processor{repository: repository.NewMemoryStorage(), deserializer: deserializer.NewJsonDeserialize()}
+	return &processor{
+		repository:   repository.NewMemoryStorage(),
+		deserializer: deserializer.NewJsonDeserialize(),
+	}
 }
 
 func (p *processor) RegisterTemplate(templateName string, template string) error {
-	return p.repository.RegisterTemplate(templateName, template)
+	t, err := p.deserializer.Deserialize(template)
+	if err != nil {
+		return err
+	}
+	return p.repository.RegisterTemplate(templateName, t)
 }
 
 func (p *processor) GenerateDocument(templateName string, content string) ([]byte, error) {
-	templateJson, err := p.repository.ReadTemplate(templateName)
+	template, err := p.repository.ReadTemplate(templateName)
 	if err != nil {
 		return nil, err
 	}
 
-	document, err := documentmapper.NewPdf(templateJson, p.deserializer, abstractfactory.NewAbstractFactoryMaps())
+	document, err := documentmapper.NewPdf(template, abstractfactory.NewAbstractFactoryMaps())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/processor/repository/memory_storage.go
+++ b/pkg/processor/repository/memory_storage.go
@@ -2,25 +2,25 @@
 package repository
 
 type memoryStorage struct {
-	template map[string]string
+	template map[string]map[string]any
 }
 
 func NewMemoryStorage() *memoryStorage {
 	return &memoryStorage{
-		template: make(map[string]string),
+		template: make(map[string]map[string]any),
 	}
 }
 
 // RegisterTemplate is responsible for register a template in memory
 //   - name is the model identifier and is used to access it
 //   - template is the template that will be stored
-func (m *memoryStorage) RegisterTemplate(name string, template string) error {
+func (m *memoryStorage) RegisterTemplate(name string, template map[string]any) error {
 	m.template[name] = template
 	return nil
 }
 
 // ReadTemplate is responsible for fetching the stored template
 //   - name is the model identifier and is used to access it
-func (m *memoryStorage) ReadTemplate(templateName string) (string, error) {
+func (m *memoryStorage) ReadTemplate(templateName string) (map[string]any, error) {
 	return m.template[templateName], nil
 }


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
The processor/repository should be able to store loaded assets in memory.
I changed the template input and output types of repository from `string` to `map[string]any`.
We can then store loaded assets as a byte slice in the repository.
Because the repository is now returning a deserialised structure, rather than a string, I updated NewPdf to take in the deserialised  structure.

I added a `Loader` interface and naive `loader` implementation which takes a path (local file path or url with scheme) and returns its contents.
I believe that the `Deserializer` should depend on the loader interface (at the very least for template parsing).
I added loader as field in the `jsonDeserializer` struct.


**Checklist**
- [ ] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [x] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [ ] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/doc.go and docs/* <!-- If applied -->
- [ ] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [x] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [x] Executed `make dod` with none issues pointed out by `golangci-lint`