### PR TITLE
feature/load-assets-with-json-deserialiser

### DIFF
--- a/pkg/processor/deserializer/json_deserializer.go
+++ b/pkg/processor/deserializer/json_deserializer.go
@@ -3,6 +3,9 @@ package deserializer
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
 
 	"github.com/johnfercher/maroto/v2/pkg/processor/core"
 	"github.com/johnfercher/maroto/v2/pkg/processor/loader"
@@ -21,5 +24,48 @@ func NewJSONDeserializer() *jsonDeserializer {
 func (j *jsonDeserializer) Deserialize(documentJSON string) (map[string]interface{}, error) {
 	var document map[string]interface{}
 	err := json.Unmarshal([]byte(documentJSON), &document)
-	return document, err
+	if err != nil {
+		return nil, err
+	}
+
+	resources, ok := document["Resources"].([]interface{})
+	if !ok {
+		return document, nil
+	}
+
+	document["Resources"] = j.loadResources(resources)
+
+	return document, nil
+}
+
+// loadResources method is responsible for loading each resource into
+// memory via go routines
+// `resources` should be type []map[string]interface{} with key "path"
+// returns []map[string]interface{} with key "data" and the associated bytes of the file
+func (j *jsonDeserializer) loadResources(resources []interface{}) []interface{} {
+	wg := sync.WaitGroup{}
+	for i, res := range resources {
+		resource, ok := res.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		path, ok := resource["path"].(string)
+		if !ok {
+			continue
+		}
+
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			data, err := j.loader.Load(path)
+			if err != nil {
+				// TODO handle errors && io gracefully
+				fmt.Fprintln(os.Stderr, err.Error())
+			}
+			resource["data"] = data
+			resources[i] = resource
+		}(i)
+	}
+	wg.Wait()
+	return resources
 }

--- a/pkg/processor/deserializer/json_deserializer_test.go
+++ b/pkg/processor/deserializer/json_deserializer_test.go
@@ -1,0 +1,69 @@
+package deserializer_test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/johnfercher/maroto/v2/pkg/processor/deserializer"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeserializer(t *testing.T) {
+	t.Run(
+		"when Resources array is not empty, it should return a document with the resources & data for each resource",
+		func(t *testing.T) {
+			input := `
+{
+  "Resources": [
+    {
+      "name": "logo",
+      "path": "../../../docs/assets/images/logo.png"
+    },
+    {
+      "name": "font",
+      "path": "../../../docs/assets/fonts/arial-unicode-ms.ttf"
+    }
+  ]
+}`
+
+			got, err := deserializer.NewJSONDeserializer().Deserialize(input)
+			assert.NoError(t, err)
+			assert.NotNil(t, got)
+			assert.Contains(t, got, "Resources")
+
+			res, ok := got["Resources"].([]interface{})
+			assert.True(t, ok)
+			assert.Len(t, res, 2)
+
+			logoFile, err := os.Open("../../../docs/assets/images/logo.png")
+			if err != nil {
+				t.Fatal(err)
+			}
+			logoBytes, err := io.ReadAll(logoFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			fontFile, err := os.Open("../../../docs/assets/fonts/arial-unicode-ms.ttf")
+			if err != nil {
+				t.Fatal(err)
+			}
+			fontBytes, err := io.ReadAll(fontFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assetBytes := [][]byte{logoBytes, fontBytes}
+
+			for i, obj := range res {
+				resource, ok := obj.(map[string]interface{})
+				assert.True(t, ok)
+				assert.Contains(t, resource, "data")
+				assert.IsType(t, resource["data"], []byte{})
+				assert.NotNil(t, resource["data"])
+				assert.Equal(t, assetBytes[i], resource["data"])
+			}
+		},
+	)
+}


### PR DESCRIPTION
<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
Update json-deserialiser to load assets into memory if the template contains a "Resources" key.
`loadResources` spins up N go routines to load each resource in to memory and waits until their done.

**Related Issue**
<!-- If it has any issue related to this PR, please add a reference here. -->

**Checklist**
> check with "x", **ONLY IF APPLIED** to your change

- [ ] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [x] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [ ] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/doc.go and docs/* <!-- If applied -->
- [ ] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [ ] Executed `make dod` with none issues pointed out by `golangci-lint`