### PR TITLE
Allow providing and retrieving the internal PDF provider

### DIFF
--- a/maroto.go
+++ b/maroto.go
@@ -56,17 +56,16 @@ func (m *Maroto) GetProvider() core.Provider {
 func New(cfgs ...*entity.Config) core.Maroto {
 	cache := cache.New()
 	cfg := getConfig(cfgs...)
-	return NewWithProvider(func() core.Provider {
-		return getProvider(cache, cfg)
-	}, cache, cfgs...)
+	provider := getProvider(cache, cfg)
+	return NewWithProvider(provider, cache, cfgs...)
 }
 
 // NewWithProvider creates a new instance of core.Maroto with a
 // custom provider factory and shared cache.
-func NewWithProvider(createProvider func() core.Provider, cache cache.Cache, cfgs ...*entity.Config) core.Maroto {
+func NewWithProvider(provider core.Provider, cache cache.Cache, cfgs ...*entity.Config) core.Maroto {
 	cfg := getConfig(cfgs...)
 	m := &Maroto{
-		provider: createProvider(),
+		provider: provider,
 		cell: entity.NewRootCell(cfg.Dimensions.Width, cfg.Dimensions.Height, entity.Margins{
 			Left:   cfg.Margins.Left,
 			Top:    cfg.Margins.Top,

--- a/maroto.go
+++ b/maroto.go
@@ -45,16 +45,28 @@ func (m *Maroto) GetCurrentConfig() *entity.Config {
 	return m.config
 }
 
+// GetProvider returns the internal PDF provider used for rendering.
+func (m *Maroto) GetProvider() core.Provider {
+	return m.provider
+}
+
 // New is responsible for create a new instance of core.Maroto.
 // It's optional to provide an *entity.Config with customizations
 // those customization are created by using the config.Builder.
 func New(cfgs ...*entity.Config) core.Maroto {
 	cache := cache.New()
 	cfg := getConfig(cfgs...)
-	provider := getProvider(cache, cfg)
+	return NewWithProvider(func() core.Provider {
+		return getProvider(cache, cfg)
+	}, cache, cfgs...)
+}
 
+// NewWithProvider creates a new instance of core.Maroto with a
+// custom provider factory and shared cache.
+func NewWithProvider(createProvider func() core.Provider, cache cache.Cache, cfgs ...*entity.Config) core.Maroto {
+	cfg := getConfig(cfgs...)
 	m := &Maroto{
-		provider: provider,
+		provider: createProvider(),
 		cell: entity.NewRootCell(cfg.Dimensions.Width, cfg.Dimensions.Height, entity.Margins{
 			Left:   cfg.Margins.Left,
 			Top:    cfg.Margins.Top,
@@ -64,7 +76,6 @@ func New(cfgs ...*entity.Config) core.Maroto {
 		cache:  cache,
 		config: cfg,
 	}
-
 	return m
 }
 

--- a/maroto.go
+++ b/maroto.go
@@ -57,7 +57,7 @@ func New(cfgs ...*entity.Config) core.Maroto {
 	cache := cache.New()
 	cfg := getConfig(cfgs...)
 	provider := getProvider(cache, cfg)
-	return NewWithProvider(provider, cache, cfgs...)
+	return NewWithProvider(provider, cache, cfg)
 }
 
 // NewWithProvider creates a new instance of core.Maroto with a


### PR DESCRIPTION
**Description**
This PR introduces two new capabilities for advanced usage:

- `NewWithProvider(...)`: allows injecting a custom PDF provider when creating a Maroto instance.
- `GetProvider()`: exposes the internal PDF provider for advanced use cases such as layout tracking, page state access, or low-level rendering extensions (e.g., form field injection).

These changes improve composability, testability, and extensibility, without breaking existing APIs.

**Related Issue**
N/A — this is a feature enhancement for power users.

**Checklist**

- [x] All methods associated with structs use `func (m *Maroto) MethodName()` style
- [ ] Wrote unit tests for new/changed features. <!-- Can be left unchecked unless you added test coverage -->
- [ ] Followed the unit test `when,should` naming pattern <!-- N/A if no tests -->
- [ ] All mocks created with `m := mocks.NewConstructor(t)` <!-- N/A -->
- [ ] All mocks using `m.EXPECT().MethodName()` <!-- N/A -->
- [ ] Updated docs/doc.go and docs/* <!-- Optional if no major doc changes -->
- [ ] Updated `example_test.go` <!-- Optional -->
- [ ] Updated README.md <!-- Optional -->
- [x] New public methods/structs/interfaces have comments explaining their responsibilities
- [x] Executed `make dod` with no issues from `golangci-lint`
