### PR TITLE
fix/remove-singleton-code-instance

### DIFF
--- a/internal/code/code.go
+++ b/internal/code/code.go
@@ -7,32 +7,23 @@ import (
 	"image/draw"
 	"image/png"
 
-	"github.com/boombuler/barcode/code128"
-	"github.com/boombuler/barcode/ean"
-	"github.com/johnfercher/maroto/v2/pkg/consts/barcode"
-
 	libBarcode "github.com/boombuler/barcode"
+	"github.com/boombuler/barcode/code128"
 	"github.com/boombuler/barcode/datamatrix"
+	"github.com/boombuler/barcode/ean"
 	"github.com/boombuler/barcode/qr"
 
+	"github.com/johnfercher/maroto/v2/pkg/consts/barcode"
 	"github.com/johnfercher/maroto/v2/pkg/consts/extension"
 	"github.com/johnfercher/maroto/v2/pkg/core/entity"
 	"github.com/johnfercher/maroto/v2/pkg/props"
 )
 
-// codeInstance is the singleton of code, opted to use a singleton to ensure that
-// this will not be instantiated more than once since there is no need to do this
-// because code is stateless.
-var codeInstance *code = nil
-
 type code struct{}
 
 // New create a Code (Singleton).
 func New() *code {
-	if codeInstance == nil {
-		codeInstance = &code{}
-	}
-	return codeInstance
+	return &code{}
 }
 
 // GenDataMatrix is responsible to generate a data matrix byte array.
@@ -76,7 +67,9 @@ func (c *code) GenBar(code string, _ *entity.Cell, prop *props.Barcode) (*entity
 	return c.getImage(scaledBarCode)
 }
 
-func getBarcodeClosure(barcodeType barcode.Type) func(code string) (libBarcode.BarcodeIntCS, error) {
+func getBarcodeClosure(
+	barcodeType barcode.Type,
+) func(code string) (libBarcode.BarcodeIntCS, error) {
 	switch barcodeType {
 	case barcode.EAN:
 		return ean.Encode


### PR DESCRIPTION
**Description**
<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->
I've removed singleton pattern usage to prevent concurrent writes when multiple maroto instances are created in parallel. Since `code` structure is an empty struct, then it's [zero bytes in size](https://www.reddit.com/r/golang/comments/1alxwnt/why_struct_is_zerosize/) and there's no point in having a singleton, as it does not optimize anything.

**Related Issue**
https://github.com/johnfercher/maroto/issues/534

**Checklist**

- [ ] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [ ] Wrote unit tests for new/changed features. <!-- If applied -->
- [ ] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [ ] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/doc.go and docs/* <!-- If applied -->
- [ ] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [x] Executed `make dod` with none issues pointed out by `golangci-lint`