### PR TITLE
refactor(props): allow negative values for position attributes

### DIFF
--- a/docs/v2/features/barcode.md
+++ b/docs/v2/features/barcode.md
@@ -9,8 +9,8 @@ The Barcode component renders a 1-D barcode inside a cell. The default type is `
 | `Type` | `barcode.Type` | `barcode.Code128` | Barcode symbology |
 | `Percent` | `float64` | `100` | How much of the cell the barcode occupies (0–100) |
 | `Center` | `bool` | `false` | Horizontally and vertically center the barcode |
-| `Left` | `float64` | `0` | Left offset in mm — ignored when `Center` is true |
-| `Top` | `float64` | `0` | Top offset in mm — ignored when `Center` is true |
+| `Left` | `float64` | `0` | Left offset in mm — ignored when `Center` is true. Accepts negative values (nudges the barcode outside the cell on the left). |
+| `Top` | `float64` | `0` | Top offset in mm — ignored when `Center` is true. Accepts negative values. |
 | `Proportion` | `props.Proportion` | `{Width:1, Height:0.2}` | Width-to-height ratio |
 
 ## Usage notes

--- a/docs/v2/features/checkbox.md
+++ b/docs/v2/features/checkbox.md
@@ -10,13 +10,13 @@ The row height for auto-row usage is `Size + Top`.
 |-------|------|---------|-------------|
 | `Checked` | `bool` | `false` | Whether the checkbox is marked with an X |
 | `Size` | `float64` | `5.0` | Side length of the checkbox square in mm |
-| `Top` | `float64` | `0` | Space between the upper cell limit and the checkbox (mm) |
-| `Left` | `float64` | `0` | Space between the left cell boundary and the checkbox (mm) |
+| `Top` | `float64` | `0` | Space between the upper cell limit and the checkbox (mm). Accepts negative values to nudge the checkbox above the cell top. |
+| `Left` | `float64` | `0` | Space between the left cell boundary and the checkbox (mm). Accepts negative values. |
 
 ## Usage notes
 
 - The label is rendered to the right of the box using the document's default font; font styling is derived from the active `core.Font`.
-- `Top` and `Left` must be ≥ 0; negative values are clamped to 0 by `MakeValid`.
+- `Top` and `Left` accept negative values (rendered slightly outside the cell on that side); `Size` is still required to be > 0 and falls back to the default `5.0` otherwise.
 - For forms with multiple options, place several `NewCol` checkboxes side-by-side in the same row.
 
 ## GoDoc

--- a/docs/v2/features/text.md
+++ b/docs/v2/features/text.md
@@ -13,10 +13,10 @@ Text can be created as a standalone `Component`, wrapped directly into a `Col`, 
 | `Size` | `float64` | global font | Font size in points |
 | `Color` | `*props.Color` | global font | Font color |
 | `Align` | `align.Type` | `align.Left` | `Left`, `Center`, `Right`, `Justify` |
-| `Top` | `float64` | `0` | Top offset inside the cell (mm) |
-| `Bottom` | `float64` | `0` | Bottom offset — used by auto rows only (mm) |
-| `Left` | `float64` | `0` | Left margin inside the cell (mm) |
-| `Right` | `float64` | `0` | Right margin inside the cell (mm) |
+| `Top` | `float64` | `0` | Top offset inside the cell (mm). Accepts negative values. |
+| `Bottom` | `float64` | `0` | Bottom offset — used by auto rows only (mm). Accepts negative values. |
+| `Left` | `float64` | `0` | Left margin inside the cell (mm). Accepts negative values. |
+| `Right` | `float64` | `0` | Right margin inside the cell (mm). Accepts negative values. |
 | `BreakLineStrategy` | `breakline.Strategy` | `EmptySpaceStrategy` | `EmptySpaceStrategy` breaks on spaces; `DashStrategy` breaks mid-word with a hyphen |
 | `VerticalPadding` | `float64` | `0` | Extra spacing between lines (mm) |
 | `Hyperlink` | `*string` | `nil` | URL — makes the text a clickable link (rendered in blue) |
@@ -24,7 +24,8 @@ Text can be created as a standalone `Component`, wrapped directly into a `Col`, 
 ## Usage notes
 
 - When `Hyperlink` is set, the text color is overridden with blue regardless of `Color`.
-- `Top` and `Left`/`Right` are clamped to the cell dimensions if they exceed it.
+- `Top` and `Left`/`Right` are clamped to the cell dimensions if they exceed it (positive over-flow).
+- `Top`, `Bottom`, `Left`, `Right` accept negative values — useful to draw text slightly outside its cell (e.g. tight padding tweaks from JSON specs). `VerticalPadding` is still clamped to ≥ 0 since negative line spacing collapses lines onto each other.
 - `BreakLineStrategy` only applies when the text does not fit on a single line.
 - For justified text on the last line, spacing may revert to default space width to avoid stretching a few characters across the full width.
 

--- a/pkg/props/barcode.go
+++ b/pkg/props/barcode.go
@@ -71,7 +71,6 @@ func (b *Barcode) ToRectProp() *Rect {
 func (b *Barcode) MakeValid() {
 	minPercentage := 0.0
 	maxPercentage := 100.0
-	minValue := 0.0
 
 	if b.Percent <= minPercentage || b.Percent > maxPercentage {
 		b.Percent = maxPercentage
@@ -80,14 +79,6 @@ func (b *Barcode) MakeValid() {
 	if b.Center {
 		b.Left = 0
 		b.Top = 0
-	}
-
-	if b.Left < minValue {
-		b.Left = minValue
-	}
-
-	if b.Top < minValue {
-		b.Top = minValue
 	}
 
 	if b.Proportion.Width <= 0 {

--- a/pkg/props/barcode_test.go
+++ b/pkg/props/barcode_test.go
@@ -85,7 +85,7 @@ func TestBarcode_MakeValid(t *testing.T) {
 		assert.Equal(t, 0.0, prop.Top)
 		assert.Equal(t, 0.0, prop.Left)
 	})
-	t.Run("when left is less than 0, should become 0", func(t *testing.T) {
+	t.Run("when left is negative, should preserve the value", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		prop := props.Barcode{
@@ -96,9 +96,9 @@ func TestBarcode_MakeValid(t *testing.T) {
 		prop.MakeValid()
 
 		// Assert
-		assert.Equal(t, 0.0, prop.Left)
+		assert.Equal(t, -5.0, prop.Left)
 	})
-	t.Run("when top is less than 0, should become 0", func(t *testing.T) {
+	t.Run("when top is negative, should preserve the value", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		prop := props.Barcode{
@@ -109,7 +109,7 @@ func TestBarcode_MakeValid(t *testing.T) {
 		prop.MakeValid()
 
 		// Assert
-		assert.Equal(t, 0.0, prop.Top)
+		assert.Equal(t, -5.0, prop.Top)
 	})
 	t.Run("when proportion.width less than 0", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/props/checkbox.go
+++ b/pkg/props/checkbox.go
@@ -40,12 +40,4 @@ func (c *Checkbox) MakeValid() {
 	if c.Size <= 0 {
 		c.Size = 5.0
 	}
-
-	if c.Top < 0 {
-		c.Top = 0
-	}
-
-	if c.Left < 0 {
-		c.Left = 0
-	}
 }

--- a/pkg/props/checkbox_test.go
+++ b/pkg/props/checkbox_test.go
@@ -44,7 +44,7 @@ func TestCheckbox_MakeValid(t *testing.T) {
 		// Assert
 		assert.Equal(t, 10.0, prop.Size)
 	})
-	t.Run("when top is negative, should apply 0", func(t *testing.T) {
+	t.Run("when top is negative, should preserve the value", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		prop := props.Checkbox{Top: -5, Size: 5}
@@ -53,7 +53,7 @@ func TestCheckbox_MakeValid(t *testing.T) {
 		prop.MakeValid()
 
 		// Assert
-		assert.Equal(t, 0.0, prop.Top)
+		assert.Equal(t, -5.0, prop.Top)
 	})
 	t.Run("when top is zero, should keep value", func(t *testing.T) {
 		t.Parallel()
@@ -77,7 +77,7 @@ func TestCheckbox_MakeValid(t *testing.T) {
 		// Assert
 		assert.Equal(t, 3.0, prop.Top)
 	})
-	t.Run("when left is negative, should apply 0", func(t *testing.T) {
+	t.Run("when left is negative, should preserve the value", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		prop := props.Checkbox{Left: -3, Size: 5}
@@ -86,7 +86,7 @@ func TestCheckbox_MakeValid(t *testing.T) {
 		prop.MakeValid()
 
 		// Assert
-		assert.Equal(t, 0.0, prop.Left)
+		assert.Equal(t, -3.0, prop.Left)
 	})
 	t.Run("when left is zero, should keep value", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/props/text.go
+++ b/pkg/props/text.go
@@ -89,7 +89,6 @@ func (t *Text) ToMap() map[string]any {
 
 // MakeValid from Text define default values for a Text.
 func (t *Text) MakeValid(font *Font) {
-	minValue := 0.0
 	undefinedValue := 0.0
 
 	if t.Family == "" {
@@ -110,22 +109,6 @@ func (t *Text) MakeValid(font *Font) {
 
 	if t.Align == "" {
 		t.Align = align.Left
-	}
-
-	if t.Top < minValue {
-		t.Top = minValue
-	}
-
-	if t.Bottom < minValue {
-		t.Bottom = minValue
-	}
-
-	if t.Left < minValue {
-		t.Left = minValue
-	}
-
-	if t.Right < minValue {
-		t.Right = minValue
 	}
 
 	if t.VerticalPadding < 0 {

--- a/pkg/props/text_test.go
+++ b/pkg/props/text_test.go
@@ -67,7 +67,7 @@ func TestText_MakeValid(t *testing.T) {
 		// Assert
 		assert.Equal(t, align.Left, prop.Align)
 	})
-	t.Run("when top is less than 0, should become 0", func(t *testing.T) {
+	t.Run("when top is negative, should preserve the value", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		prop := props.Text{
@@ -78,9 +78,9 @@ func TestText_MakeValid(t *testing.T) {
 		prop.MakeValid(&props.Font{Family: fontfamily.Arial, Size: 10, Style: fontstyle.Normal})
 
 		// Assert
-		assert.Equal(t, 0.0, prop.Top)
+		assert.Equal(t, -5.0, prop.Top)
 	})
-	t.Run("when left is less than 0, should become 0", func(t *testing.T) {
+	t.Run("when left is negative, should preserve the value", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		prop := props.Text{
@@ -91,9 +91,9 @@ func TestText_MakeValid(t *testing.T) {
 		prop.MakeValid(&props.Font{Family: fontfamily.Arial, Size: 10, Style: fontstyle.Normal})
 
 		// Assert
-		assert.Equal(t, 0.0, prop.Left)
+		assert.Equal(t, -5.0, prop.Left)
 	})
-	t.Run("when right is less than 0, should become 0", func(t *testing.T) {
+	t.Run("when right is negative, should preserve the value", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		prop := props.Text{
@@ -104,7 +104,7 @@ func TestText_MakeValid(t *testing.T) {
 		prop.MakeValid(&props.Font{Family: fontfamily.Arial, Size: 10, Style: fontstyle.Normal})
 
 		// Assert
-		assert.Equal(t, 0.0, prop.Right)
+		assert.Equal(t, -5.0, prop.Right)
 	})
 	t.Run("when vertical padding is less than 0, should become 0", func(t *testing.T) {
 		t.Parallel()
@@ -133,7 +133,7 @@ func TestText_MakeValid(t *testing.T) {
 		// Assert
 		assert.Equal(t, color, prop.Color)
 	})
-	t.Run("when bottom is less than 0, should become 0", func(t *testing.T) {
+	t.Run("when bottom is negative, should preserve the value", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		prop := props.Text{
@@ -144,7 +144,7 @@ func TestText_MakeValid(t *testing.T) {
 		prop.MakeValid(&props.Font{Family: fontfamily.Arial, Size: 10, Style: fontstyle.Normal})
 
 		// Assert
-		assert.Equal(t, 0.0, prop.Bottom)
+		assert.Equal(t, -5.0, prop.Bottom)
 	})
 	t.Run("when break line strategy is empty, should apply empty space strategy", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
Removed constraints enforcing non-negative values for `Top`, `Left`, `Right`, and `Bottom` attributes across components. Adjusted tests to account for preserving negative values.

**Description**
Allows negative values for `Top` / `Bottom` / `Left` / `Right` on `props.Text`, `props.Barcode`, and `props.Checkbox`. Previously `MakeValid` clamped any negative offset back to `0`, silently killing inputs like `{ "padding": { "top":
  -3, "left": -2 } }` that downstream JSON specs forward to the renderer.

  Purely additive: `>= 0` values keep their existing behavior; only the previously-impossible `< 0` cases start working. Fields with a real geometric reason to refuse negatives (`Size`, `Percent`, `Proportion`, `VerticalPadding`, font
  fallbacks) keep their clamps.

  Provider-side upper-bound checks (`if textProp.Top > cell.Height` etc.) are unaffected — they clamp too-positive values, not too-negative ones.

**Related Issue**
N/A

**Checklist**
- [x] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [x] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [x] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [x] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [x] Updated docs/* <!-- If applied -->
- [ ] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [x] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [x] Executed `make dod` with none issues pointed out by `golangci-lint`