### PR TITLE
feat(checkbox): render checkmark instead of X when checked

### DIFF
--- a/docs/v2/features/checkbox.md
+++ b/docs/v2/features/checkbox.md
@@ -1,6 +1,6 @@
 # Checkbox
 
-The Checkbox component renders a square checkbox with an optional label to its right. When `Checked` is true, an X mark is drawn inside the box. This component is useful for forms, questionnaires, and agreements.
+The Checkbox component renders a square checkbox with an optional label to its right. When `Checked` is true, a checkmark (✓) is drawn inside the box using two line strokes. This component is useful for forms, questionnaires, and agreements.
 
 The row height for auto-row usage is `Size + Top`.
 
@@ -8,7 +8,7 @@ The row height for auto-row usage is `Size + Top`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `Checked` | `bool` | `false` | Whether the checkbox is marked with an X |
+| `Checked` | `bool` | `false` | Whether the checkbox is marked with a checkmark |
 | `Size` | `float64` | `5.0` | Side length of the checkbox square in mm |
 | `Top` | `float64` | `0` | Space between the upper cell limit and the checkbox (mm) |
 | `Left` | `float64` | `0` | Space between the left cell boundary and the checkbox (mm) |

--- a/internal/providers/gofpdf/checkbox.go
+++ b/internal/providers/gofpdf/checkbox.go
@@ -30,9 +30,18 @@ func (c *Checkbox) Add(label string, cell *entity.Cell, prop *props.Checkbox) {
 	c.pdf.Rect(x, y, prop.Size, prop.Size, "D")
 
 	if prop.Checked {
-		// Draw X mark inside the box
-		c.pdf.Line(x, y, x+prop.Size, y+prop.Size)
-		c.pdf.Line(x+prop.Size, y, x, y+prop.Size)
+		// Draw a checkmark (✓) inside the box using two line segments:
+		// a short descending stroke from the lower-left toward the valley,
+		// followed by a longer ascending stroke up to the upper-right.
+		startX := x + prop.Size*0.2
+		startY := y + prop.Size*0.5
+		midX := x + prop.Size*0.4
+		midY := y + prop.Size*0.75
+		endX := x + prop.Size*0.85
+		endY := y + prop.Size*0.2
+
+		c.pdf.Line(startX, startY, midX, midY)
+		c.pdf.Line(midX, midY, endX, endY)
 	}
 
 	// Draw label to the right of the checkbox, vertically centered

--- a/internal/providers/gofpdf/checkbox_test.go
+++ b/internal/providers/gofpdf/checkbox_test.go
@@ -49,7 +49,7 @@ func TestCheckbox_Add(t *testing.T) {
 		// Act
 		sut.Add("", cell, prop)
 	})
-	t.Run("when label is empty and checkbox is checked, should draw border rect and X mark lines", func(t *testing.T) {
+	t.Run("when label is empty and checkbox is checked, should draw border rect and checkmark lines", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		cell := &entity.Cell{X: 0, Y: 0}
@@ -64,10 +64,10 @@ func TestCheckbox_Add(t *testing.T) {
 		fpdf.EXPECT().GetMargins().Return(0.0, 0.0, 0.0, 0.0)
 		// x = 0 + 0 + 0 = 0, y = 0 + 0 + 0 = 0
 		fpdf.EXPECT().Rect(0.0, 0.0, 10.0, 10.0, "D")
-		// diagonal top-left to bottom-right
-		fpdf.EXPECT().Line(0.0, 0.0, 10.0, 10.0)
-		// diagonal top-right to bottom-left
-		fpdf.EXPECT().Line(10.0, 0.0, 0.0, 10.0)
+		// checkmark: short descending stroke from (0.2*size, 0.5*size) to (0.4*size, 0.75*size)
+		fpdf.EXPECT().Line(2.0, 5.0, 4.0, 7.5)
+		// checkmark: long ascending stroke from (0.4*size, 0.75*size) to (0.85*size, 0.2*size)
+		fpdf.EXPECT().Line(4.0, 7.5, 8.5, 2.0)
 
 		font := mocks.NewFont(t)
 
@@ -104,7 +104,7 @@ func TestCheckbox_Add(t *testing.T) {
 		// Act
 		sut.Add("label", cell, prop)
 	})
-	t.Run("when label is set and checkbox is checked, should draw border rect, X mark lines and label text", func(t *testing.T) {
+	t.Run("when label is set and checkbox is checked, should draw border rect, checkmark lines and label text", func(t *testing.T) {
 		t.Parallel()
 		// Arrange
 		cell := &entity.Cell{X: 0, Y: 0}
@@ -119,8 +119,9 @@ func TestCheckbox_Add(t *testing.T) {
 		fpdf.EXPECT().GetMargins().Return(0.0, 0.0, 0.0, 0.0)
 		// x = 0, y = 0
 		fpdf.EXPECT().Rect(0.0, 0.0, 10.0, 10.0, "D")
-		fpdf.EXPECT().Line(0.0, 0.0, 10.0, 10.0)
-		fpdf.EXPECT().Line(10.0, 0.0, 0.0, 10.0)
+		// checkmark strokes: (0.2,0.5)*size -> (0.4,0.75)*size -> (0.85,0.2)*size
+		fpdf.EXPECT().Line(2.0, 5.0, 4.0, 7.5)
+		fpdf.EXPECT().Line(4.0, 7.5, 8.5, 2.0)
 		// labelX = 0 + 10 + 1 = 11
 		// labelY = 0 + 5 + 2 = 7
 		fpdf.EXPECT().Text(11.0, 7.0, "option")


### PR DESCRIPTION
The Checkbox component previously rendered a checked state by drawing two diagonal lines forming an "X" across the box. Replace that with a proper checkmark glyph (✓) built from two line strokes:

  - a short descending stroke from (0.2*size, 0.5*size) to (0.4*size, 0.75*size), i.e. the valley of the check, and
  - a longer ascending stroke from the valley up to (0.85*size, 0.2*size), i.e. the tip of the check.

Update the affected unit tests in internal/providers/gofpdf/checkbox_test.go to expect the new Line coordinates, and refresh the user-facing docs (docs/v2/features/checkbox.md) so they describe a checkmark rather than an X.

<!-- Please follow the PR naming pattern. -->
<!-- For features: feature/name -->
<!-- For fixes: fix/name -->

**Description**
<!-- Please, describe how this PR will be useful. If it has any tricky technical detail, please explain too. -->

**Related Issue**
<!-- If it has any issue related to this PR, please add a reference here. -->

**Checklist**
> check with "x", **ONLY IF APPLIED** to your change

- [ ] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [ ] Wrote unit tests for new/changed features. <!-- If applied -->
- [ ] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [ ] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/* <!-- If applied -->
- [ ] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [ ] Executed `make dod` with none issues pointed out by `golangci-lint`