### PR TITLE
fix: eliminate race condition in concurrent mode with custom font

### DIFF
--- a/internal/providers/gofpdf/builder.go
+++ b/internal/providers/gofpdf/builder.go
@@ -1,6 +1,8 @@
 package gofpdf
 
 import (
+	"slices"
+
 	"github.com/phpdave11/gofpdf"
 
 	"github.com/johnfercher/maroto/v2/internal/cache"
@@ -51,7 +53,7 @@ func (b *builder) Build(cfg *entity.Config, cache cache.Cache) *Dependencies {
 	})
 
 	for _, font := range cfg.CustomFonts {
-		fpdf.AddUTF8FontFromBytes(font.GetFamily(), string(font.GetStyle()), font.GetBytes())
+		fpdf.AddUTF8FontFromBytes(font.GetFamily(), string(font.GetStyle()), slices.Clone(font.GetBytes()))
 	}
 
 	if cfg.DisableAutoPageBreak {

--- a/maroto_test.go
+++ b/maroto_test.go
@@ -2,18 +2,21 @@ package maroto_test
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"testing"
 	"time"
 
 	"github.com/johnfercher/maroto/v2/pkg/components/code"
-	"github.com/johnfercher/maroto/v2/pkg/components/text"
-
 	"github.com/johnfercher/maroto/v2/pkg/components/col"
 	"github.com/johnfercher/maroto/v2/pkg/components/page"
 	"github.com/johnfercher/maroto/v2/pkg/components/row"
+	"github.com/johnfercher/maroto/v2/pkg/components/text"
 	"github.com/johnfercher/maroto/v2/pkg/config"
+	"github.com/johnfercher/maroto/v2/pkg/consts/fontstyle"
 	"github.com/johnfercher/maroto/v2/pkg/core"
+	"github.com/johnfercher/maroto/v2/pkg/fontrepository"
+	"github.com/johnfercher/maroto/v2/pkg/props"
 	"github.com/johnfercher/maroto/v2/pkg/test"
 
 	"github.com/johnfercher/maroto/v2"
@@ -596,5 +599,31 @@ func TestMaroto_RegisterFooter(t *testing.T) {
 		// Assert
 		assert.Nil(t, err)
 		test.New(t).Assert(sut.GetStructure()).Equals("footer_auto_row.json")
+	})
+
+	t.Run("when running with concurrent mode, no race condition while accessing font", func(t *testing.T) {
+		fontData, err := os.ReadFile("docs/assets/fonts/arial-unicode-ms.ttf")
+		assert.NoError(t, err)
+		customFonts, err := fontrepository.New().
+			AddUTF8FontFromBytes("customFontName", fontstyle.Normal, fontData).
+			Load()
+
+		assert.NoError(t, err)
+
+		row := row.New(10).Add(col.New())
+		cfg := config.NewBuilder().
+			WithCustomFonts(customFonts).
+			WithDefaultFont(&props.Font{Family: "customFontName", Size: 16}).
+			WithConcurrentMode(4).
+			Build()
+
+		m := maroto.New(cfg)
+		for range 150 {
+			// Generate multiple pages
+			m.AddRows(row)
+		}
+
+		_, err = m.Generate()
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
**Description**
gofpdf mutates the slice during GenerateCutFont via append-padding in generateChecksum, causing write/write races when the same bytes are shared across Fpdf instances.


This PR fixes the issue by copying byte slice


**Related Issue**
[<!-- If it has any issue related to this PR, please add a reference here. -->](https://github.com/johnfercher/maroto/issues/550)

**Checklist**
> check with "x", **ONLY IF APPLIED** to your change

- [ ] All methods associated with structs has ```func (<first letter of struct> *struct) method() {}``` name style. <!-- If applied -->
- [x] Wrote unit tests for new/changed features. <!-- If applied -->
- [x] Followed the unit test ```when,should``` naming pattern. <!-- If applied -->
- [ ] All mocks created with ```m := mocks.NewConstructor(t)```. <!-- If applied -->
- [x] All mocks using ```m.EXPECT().MethodName()``` method to mock methods. <!-- If applied -->
- [ ] Updated docs/* <!-- If applied -->
- [x] Updated ```example_test.go```. <!-- If applied -->
- [ ] Updated README.md <!-- If applied -->
- [ ] New public methods/structs/interfaces has comments upside them explaining they responsibilities <!-- If applied -->
- [ ] Executed `make dod` with none issues pointed out by `golangci-lint`